### PR TITLE
Improve production build

### DIFF
--- a/frontend/src/Explorer/Api/Http.purs
+++ b/frontend/src/Explorer/Api/Http.purs
@@ -9,7 +9,6 @@ import Data.Either (Either(..), either)
 import Data.Generic (class Generic)
 import Data.HTTP.Method (Method(..))
 import Data.Lens ((^.))
-import Debug.Trace (trace, traceAny)
 import Explorer.Api.Helper (decodeResult)
 import Explorer.Api.Types (EndpointError(..), Endpoint)
 import Explorer.Types.State (CBlockEntries, CTxEntries)
@@ -39,7 +38,7 @@ request req endpoint = do
       isHttpError (StatusCode c) = c >= 400
 
 get :: forall eff a. Generic a => Endpoint -> Aff (ajax :: AJAX | eff) a
-get e = trace "get" \_ -> traceAny e \_ -> request defaultRequest e
+get e = request defaultRequest e
 
 post :: forall eff a. Generic a => Endpoint -> Aff (ajax :: AJAX | eff) a
 post = request $ defaultRequest { method = Left POST }

--- a/frontend/webpack.config.babel.js
+++ b/frontend/webpack.config.babel.js
@@ -90,7 +90,8 @@ module.exports = {
             path.join('src', '**', '*.purs'),
             path.join('bower_components', 'purescript-*', 'src', '**', '*.purs')
           ],
-          watch: !isProd
+          watch: !isProd,
+          bundle: isProd,
         }
       },
       {


### PR DESCRIPTION
**_tl;dr_**
Before: `1,3 MB`
After: `573 KB` 

**_summary_**
By using `psc-bundle` to eliminate dead code we have in production mode a `js` file size of `573 KB` now. It was `1,3 MB` before, even by using `UglifyJsPlugin`.