### PR TITLE
[CSE-42] Implement `address summary` endpoint 

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,3 +13,4 @@ src/Generated/*
 src/Data/Time/Lenses/*
 src/Explorer/I18n/Lenses.purs
 src/Explorer/Lenses/*
+src/Explorer/View/Lenses/*

--- a/frontend/scripts/generate-frontend-lenses.sh
+++ b/frontend/scripts/generate-frontend-lenses.sh
@@ -41,3 +41,21 @@ purescript-derive-lenses \
     --moduleName Data.Time.NominalDiffTime.Lenses \
     --moduleImports "import Data.Time.Duration  (Seconds (..))" \
     > $DIR_TIME_LENSES/NominalDiffTime.purs
+
+# - - - - - - - - - - -
+# View
+# - - - - - - - - - - -
+
+DIR_VIEW=src/Explorer/View
+DIR_VIEW_LENSES=$DIR_VIEW/Lenses
+
+mkdir -p $DIR_VIEW_LENSES
+
+purescript-derive-lenses \
+    < $DIR_VIEW/Types.purs \
+    --moduleName Explorer.View.Lenses \
+    --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
+    --moduleImports "import Data.Maybe (Maybe)" \
+    --moduleImports "import Pos.Core.Types (Coin)" \
+    --moduleImports "import Pos.Explorer.Web.ClientTypes (CTxId)" \
+    > $DIR_VIEW_LENSES/View.purs

--- a/frontend/scripts/generate-frontend-lenses.sh
+++ b/frontend/scripts/generate-frontend-lenses.sh
@@ -56,6 +56,7 @@ purescript-derive-lenses \
     --moduleName Explorer.View.Lenses \
     --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
     --moduleImports "import Data.Maybe (Maybe)" \
+    --moduleImports "import Data.Tuple (Tuple)" \
     --moduleImports "import Pos.Core.Types (Coin)" \
-    --moduleImports "import Pos.Explorer.Web.ClientTypes (CTxId)" \
+    --moduleImports "import Pos.Explorer.Web.ClientTypes (CAddress, CTxId)" \
     > $DIR_VIEW_LENSES/View.purs

--- a/frontend/src/Explorer/Api/Http.purs
+++ b/frontend/src/Explorer/Api/Http.purs
@@ -8,7 +8,6 @@ import Data.Argonaut.Core (Json)
 import Data.Either (Either(..), either)
 import Data.Generic (class Generic)
 import Data.HTTP.Method (Method(..))
-import Data.Lens ((^.))
 import Debug.Trace (trace, traceAny)
 import Explorer.Api.Helper (decodeResult)
 import Explorer.Api.Types (EndpointError(..), Endpoint)
@@ -16,8 +15,7 @@ import Explorer.Types.State (CBlockEntries, CTxEntries)
 import Network.HTTP.Affjax (AJAX, AffjaxRequest, affjax, defaultRequest)
 import Network.HTTP.Affjax.Request (class Requestable)
 import Network.HTTP.StatusCode (StatusCode(..))
-import Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary, CBlockSummary, CHash)
-import Pos.Explorer.Web.Lenses.ClientTypes (_CHash, _CAddress)
+import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary, CBlockSummary, CHash(..))
 
 endpointPrefix :: String
 -- endpointPrefix = "http://localhost:8100/api/"
@@ -51,10 +49,10 @@ fetchLatestBlocks :: forall eff. Aff (ajax::AJAX | eff) CBlockEntries
 fetchLatestBlocks = get "blocks/last"
 
 fetchBlockSummary :: forall eff. CHash -> Aff (ajax::AJAX | eff) CBlockSummary
-fetchBlockSummary hash = get $ "blocks/summary/" <> hash ^. _CHash
+fetchBlockSummary (CHash hash) = get $ "blocks/summary/" <> hash
 
 fetchBlockTxs :: forall eff. CHash -> Aff (ajax::AJAX | eff) CTxEntries
-fetchBlockTxs hash = get $ "blocks/txs/" <> hash ^. _CHash
+fetchBlockTxs (CHash hash) = get $ "blocks/txs/" <> hash
 
 -- txs
 fetchLatestTxs :: forall eff. Aff (ajax::AJAX | eff) CTxEntries
@@ -62,4 +60,4 @@ fetchLatestTxs = get "txs/last"
 
 -- addresses
 fetchAddressSummary :: forall eff. CAddress -> Aff (ajax::AJAX | eff) CAddressSummary
-fetchAddressSummary address = get $ "addresses/summary/" <> address ^. _CAddress
+fetchAddressSummary (CAddress address) = get $ "addresses/summary/" <> address

--- a/frontend/src/Explorer/State.purs
+++ b/frontend/src/Explorer/State.purs
@@ -33,7 +33,7 @@ initialState =
     , handleLatestBlocksSocketResult: false
     , initialTxsRequested: false
     , handleLatestTxsSocketResult: false
-    , currentBlock: Nothing
+    , currentBlockSummary: Nothing
     , currentBlockTxs: []
     , latestTransactions: []
     , currentAddressSummary: Nothing

--- a/frontend/src/Explorer/Types/Actions.purs
+++ b/frontend/src/Explorer/Types/Actions.purs
@@ -41,7 +41,7 @@ data Action
     | DashboardSearch                       -- dasboard search
     | DashboardFocusSearchInput Boolean
     -- address detail
-    | AddressPaginateTransactions Int       -- current pagination of transactions
+    | AddressPaginateTxs Int       -- current pagination of transactions
     -- block detail
     | BlockPaginateTransactions Int       -- current pagination of transactions
     -- misc

--- a/frontend/src/Explorer/Types/State.purs
+++ b/frontend/src/Explorer/Types/State.purs
@@ -18,7 +18,7 @@ type State =
     , handleLatestBlocksSocketResult :: Boolean
     , initialTxsRequested :: Boolean
     , handleLatestTxsSocketResult :: Boolean
-    , currentBlock :: Maybe CBlockSummary
+    , currentBlockSummary :: Maybe CBlockSummary
     , currentBlockTxs :: CTxEntries
     , latestTransactions :: CTxEntries
     , currentAddressSummary :: Maybe CAddressSummary

--- a/frontend/src/Explorer/Util/Factory.Test.purs
+++ b/frontend/src/Explorer/Util/Factory.Test.purs
@@ -1,0 +1,28 @@
+module Explorer.Util.Factory.Test where
+
+import Prelude
+import Control.Monad.Aff (Aff)
+import Control.Monad.State (StateT)
+import Data.Identity (Identity)
+import Data.Lens ((^.))
+import Data.Tuple (Tuple(..))
+import Explorer.Util.Factory (mkCAddress, mkCoin, sumCoinOfInputsOutputs)
+import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Test.Spec (Group, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+testFactoryUtil :: forall r. StateT (Array (Group (Aff r Unit))) Identity Unit
+testFactoryUtil =
+    describe "Explorer.Util.Factory" do
+        describe "sumCoinOfInputsOutputs" do
+          it "sums a list of Coins"
+            let list =  [ (Tuple (mkCAddress "a") (mkCoin 3))
+                        , (Tuple (mkCAddress "b") (mkCoin 3))
+                        ]
+                coin = sumCoinOfInputsOutputs list
+                result = coin ^. (_Coin <<< getCoin)
+            in result `shouldEqual` 6
+          it "sums an empty list of Coins"
+            let coin = sumCoinOfInputsOutputs []
+                result = coin ^. (_Coin <<< getCoin)
+            in result `shouldEqual` 0

--- a/frontend/src/Explorer/Util/Factory.purs
+++ b/frontend/src/Explorer/Util/Factory.purs
@@ -1,9 +1,11 @@
 module Explorer.Util.Factory where
 
 import Prelude
+import Data.Lens ((^.))
 import Data.Time.NominalDiffTime (mkTime)
 import Pos.Core.Types (Coin(..))
-import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxEntry(..), CTxId(..))
+import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxBrief(..), CTxEntry(..), CTxId(..))
+import Pos.Explorer.Web.Lenses.ClientTypes (ctbId, ctbTimeIssued)
 
 
 mkCHash :: String -> CHash
@@ -20,9 +22,20 @@ mkCoin coin =
 mkCAddress :: String -> CAddress
 mkCAddress = CAddress
 
+class CTxEntryFactory a where
+    mkCTxEntryFrom :: a -> CTxEntry
+
+instance txBriefCTxEntryFactory :: CTxEntryFactory CTxBrief where
+    mkCTxEntryFrom (CTxBrief txBrief) = CTxEntry
+      { cteId: txBrief ^. ctbId
+      , cteTimeIssued: txBrief ^. ctbTimeIssued
+      , cteAmount: mkCoin 0 -- TODO(jk) We do need an amount here
+      }
+
 -- All the following helper function `mkEmpty**` are for debugging only
 -- We do need these to mock live data
 -- It can be removed if all endpoints are ready
+
 
 mkEmptyCTxEntry :: CTxEntry
 mkEmptyCTxEntry = CTxEntry

--- a/frontend/src/Explorer/Util/Factory.purs
+++ b/frontend/src/Explorer/Util/Factory.purs
@@ -1,11 +1,9 @@
 module Explorer.Util.Factory where
 
 import Prelude
-import Data.Lens ((^.))
 import Data.Time.NominalDiffTime (mkTime)
 import Pos.Core.Types (Coin(..))
-import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxBrief(..), CTxEntry(..), CTxId(..))
-import Pos.Explorer.Web.Lenses.ClientTypes (ctbId, ctbTimeIssued)
+import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxEntry(..), CTxId(..))
 
 
 mkCHash :: String -> CHash
@@ -22,15 +20,25 @@ mkCoin coin =
 mkCAddress :: String -> CAddress
 mkCAddress = CAddress
 
-class CTxEntryFactory a where
-    mkCTxEntryFrom :: a -> CTxEntry
-
-instance txBriefCTxEntryFactory :: CTxEntryFactory CTxBrief where
-    mkCTxEntryFrom (CTxBrief txBrief) = CTxEntry
-      { cteId: txBrief ^. ctbId
-      , cteTimeIssued: txBrief ^. ctbTimeIssued
-      , cteAmount: mkCoin 0 -- TODO(jk) We do need an amount here
-      }
+-- -- | Factory to create CTxEntry by a given type
+-- class CTxEntryFactory a where
+--     mkCTxEntryFrom :: a -> CTxEntry
+--
+-- -- | Creates a CTxEntry by a given CTxBrief
+-- instance cTxBriefCTxEntryFactory :: CTxEntryFactory CTxBrief where
+--     mkCTxEntryFrom (CTxBrief txBrief) = CTxEntry
+--       { cteId: txBrief ^. ctbId
+--       , cteTimeIssued: txBrief ^. ctbTimeIssued
+--       , cteAmount: mkCoin 0 -- TODO(jk) We do need an amount here
+--       }
+--
+-- -- | Creates a CTxEntry by a given CTxSummary
+-- instance cTxSummaryCTxEntryFactory :: CTxEntryFactory CTxSummary where
+--     mkCTxEntryFrom (CTxSummary txSummary) = CTxSummary
+--       { cteId: txSummary ^. ctsId
+--       , cteTimeIssued: txSummary ^. ctsBlockTimeIssued
+--       , cteAmount: txSummary ^. ctsTotalOutput
+--       }
 
 -- All the following helper function `mkEmpty**` are for debugging only
 -- We do need these to mock live data

--- a/frontend/src/Explorer/Util/Factory.purs
+++ b/frontend/src/Explorer/Util/Factory.purs
@@ -20,26 +20,6 @@ mkCoin coin =
 mkCAddress :: String -> CAddress
 mkCAddress = CAddress
 
--- -- | Factory to create CTxEntry by a given type
--- class CTxEntryFactory a where
---     mkCTxEntryFrom :: a -> CTxEntry
---
--- -- | Creates a CTxEntry by a given CTxBrief
--- instance cTxBriefCTxEntryFactory :: CTxEntryFactory CTxBrief where
---     mkCTxEntryFrom (CTxBrief txBrief) = CTxEntry
---       { cteId: txBrief ^. ctbId
---       , cteTimeIssued: txBrief ^. ctbTimeIssued
---       , cteAmount: mkCoin 0 -- TODO(jk) We do need an amount here
---       }
---
--- -- | Creates a CTxEntry by a given CTxSummary
--- instance cTxSummaryCTxEntryFactory :: CTxEntryFactory CTxSummary where
---     mkCTxEntryFrom (CTxSummary txSummary) = CTxSummary
---       { cteId: txSummary ^. ctsId
---       , cteTimeIssued: txSummary ^. ctsBlockTimeIssued
---       , cteAmount: txSummary ^. ctsTotalOutput
---       }
-
 -- All the following helper function `mkEmpty**` are for debugging only
 -- We do need these to mock live data
 -- It can be removed if all endpoints are ready

--- a/frontend/src/Explorer/Util/Factory.purs
+++ b/frontend/src/Explorer/Util/Factory.purs
@@ -1,7 +1,11 @@
 module Explorer.Util.Factory where
 
 import Prelude
+import Data.Array (foldl)
 import Data.Time.NominalDiffTime (mkTime)
+import Data.Tuple (Tuple(..))
+import Data.Lens ((^.))
+import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Core.Types (Coin(..))
 import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxEntry(..), CTxId(..))
 
@@ -19,6 +23,11 @@ mkCoin coin =
 
 mkCAddress :: String -> CAddress
 mkCAddress = CAddress
+
+-- | Helper to summarize coins by a list of Tx inputs or outputs
+sumCoinOfInputsOutputs :: Array (Tuple CAddress Coin) -> Coin
+sumCoinOfInputsOutputs list =
+    mkCoin $ foldl (\acc (Tuple _ coin) -> (+) acc $ coin ^. (_Coin <<< getCoin)) 0 list
 
 -- All the following helper function `mkEmpty**` are for debugging only
 -- We do need these to mock live data

--- a/frontend/src/Explorer/Util/String.Test.purs
+++ b/frontend/src/Explorer/Util/String.Test.purs
@@ -8,23 +8,23 @@ import Explorer.Util.String (substitute)
 import Test.Spec (Group, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
-testStringUtil :: forall eff. StateT (Array (Group (Aff eff Unit))) Identity Unit
+testStringUtil :: forall r. StateT (Array (Group (Aff r Unit))) Identity Unit
 testStringUtil =
-  describe "Explorer.Util.String" do
-    describe "substitute" do
-      it "takes all two arguments" do
-        let result = substitute "Hello {0}, what's going on {1}?" ["Jane", "today"]
-        let expected = "Hello Jane, what's going on today?"
-        result `shouldEqual` expected
-      it "takes the third argument only" do
-        let result = substitute "Hello {2}" ["foo", "bar", "baz"]
-        let expected = "Hello baz"
-        result `shouldEqual` expected
-      it "ignores all extra arguments" do
-        let result = substitute "Hello {0}, what's going on?" ["foo", "bar", "baz"]
-        let expected = "Hello foo, what's going on?"
-        result `shouldEqual` expected
-      it "ignores placeholder if an argument is missing" do
-        let result = substitute "Hello {0}, let's go now" []
-        let expected = "Hello , let's go now"
-        result `shouldEqual` expected
+    describe "Explorer.Util.String" do
+        describe "substitute" do
+            it "takes all two arguments" do
+                let result = substitute "Hello {0}, what's going on {1}?" ["Jane", "today"]
+                    expected = "Hello Jane, what's going on today?"
+                result `shouldEqual` expected
+            it "takes the third argument only" do
+                let result = substitute "Hello {2}" ["foo", "bar", "baz"]
+                    expected = "Hello baz"
+                result `shouldEqual` expected
+            it "ignores all extra arguments" do
+                let result = substitute "Hello {0}, what's going on?" ["foo", "bar", "baz"]
+                    expected = "Hello foo, what's going on?"
+                result `shouldEqual` expected
+            it "ignores placeholder if an argument is missing" do
+                let result = substitute "Hello {0}, let's go now" []
+                    expected = "Hello , let's go now"
+                result `shouldEqual` expected

--- a/frontend/src/Explorer/Util/Time.Test.purs
+++ b/frontend/src/Explorer/Util/Time.Test.purs
@@ -10,29 +10,29 @@ import Explorer.Util.Time (prettyDuration)
 import Test.Spec (Group, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
-testPrettyDuration :: forall eff. StateT (Array (Group (Aff eff Unit))) Identity Unit
+testPrettyDuration :: forall r. StateT (Array (Group (Aff r Unit))) Identity Unit
 testPrettyDuration =
-  describe "Explorer.Util.Time.Test.prettyDuration" do
-    describe "short durations" do
-      it "a milisecond should return less than a minute" do
-        let result = prettyDuration English (Milliseconds 1.0)
-        let expected = "< 1 Minutes"
-        result `shouldEqual` expected
-      it "a second should return less than a minute" do
-        let result = prettyDuration English (Seconds 1.0)
-        let expected = "< 1 Minutes"
-        result `shouldEqual` expected
-      it "59 seconds should return less than a minute" do
-        let result = prettyDuration English (Seconds 59.0)
-        let expected = "< 1 Minutes"
-        result `shouldEqual` expected
-    describe "durations" do
-      it "30 minutes should return 30 minutes" do
-        let result = prettyDuration English (Minutes 30.0)
-        let expected = "30 Minutes"
-        result `shouldEqual` expected
-    describe "longer durations" do
-      it "5 days should return 5 days" do
-        let result = prettyDuration English (Days 5.0)
-        let expected = "5 Days"
-        result `shouldEqual` expected
+    describe "Explorer.Util.Time.Test.prettyDuration" do
+        describe "short durations" do
+            it "a milisecond should return less than a minute" do
+              let result = prettyDuration English (Milliseconds 1.0)
+                  expected = "< 1 Minutes"
+              result `shouldEqual` expected
+            it "a second should return less than a minute" do
+              let result = prettyDuration English (Seconds 1.0)
+                  expected = "< 1 Minutes"
+              result `shouldEqual` expected
+            it "59 seconds should return less than a minute" do
+              let result = prettyDuration English (Seconds 59.0)
+                  expected = "< 1 Minutes"
+              result `shouldEqual` expected
+        describe "durations" do
+            it "30 minutes should return 30 minutes" do
+                let result = prettyDuration English (Minutes 30.0)
+                    expected = "30 Minutes"
+                result `shouldEqual` expected
+        describe "longer durations" do
+          it "5 days should return 5 days" do
+              let result = prettyDuration English (Days 5.0)
+                  expected = "5 Days"
+              result `shouldEqual` expected

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -10,7 +10,7 @@ import Explorer.Lenses.State (addressDetail, addressTxPagination, currentAddress
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
+import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txPaginationView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CAddressSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxList, caTxNum)
@@ -61,10 +61,10 @@ addressView state =
                                       [ txHeaderView $ case currentTxBrief of
                                                             Nothing -> mkTxHeaderViewProps mkEmptyViewProps
                                                             Just txBrief -> mkTxHeaderViewProps txBrief
-                                      , transactionBodyView $ case currentTxBrief of
+                                      , txBodyView $ case currentTxBrief of
                                                                   Nothing -> mkTxBodyViewProps mkEmptyViewProps
                                                                   Just txBrief -> mkTxBodyViewProps txBrief
-                                      , transactionPaginationView
+                                      , txPaginationView
                                             { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
                                             , currentPage: txPagination
                                             , maxPage: length txList

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -7,17 +7,15 @@ import Data.Maybe (Maybe(..))
 import Explorer.I18n.Lang (Language, translate)
 import Explorer.I18n.Lenses (cAddress, common, cOf, cTransactions, address, addScan, addQrCode, addFinalBalance) as I18nL
 import Explorer.Lenses.State (addressDetail, addressTxPagination, currentAddressSummary, lang, viewStates)
-import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.View.Common (currencyCSSClass, mkEmptyProps, mkTxHeaderViewProps, transactionBodyView, txHeaderView, transactionPaginationView)
+import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CAddressSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxList, caTxNum)
 import Pux.Html (Html, div, text, h3, p) as P
 import Pux.Html.Attributes (className, id_) as P
-import Pux.Router (link) as P
 
 addressView :: State -> P.Html Action
 addressView state =
@@ -53,25 +51,24 @@ addressView state =
                           [ P.className "headline"]
                           [ P.text $ translate (I18nL.common <<< I18nL.cTransactions) lang' ]
                         , case state ^. currentAddressSummary of
-                              Nothing ->
-                                  -- TODO (jk) Use `emptyTxHeaderView` if #15 has been merged
-                                  P.div
-                                      [ P.className "transaction-header"]
-                                      [ ]
+                              Nothing -> emptyTxHeaderView state
                               Just (CAddressSummary addressSummary) ->
                                   let txList = addressSummary ^. caTxList
                                       txPagination = state ^. (viewStates <<< addressDetail <<< addressTxPagination)
+                                      currentTxBrief = txList !! (txPagination - 1)
                                   in
                                   P.div
                                       []
-                                      [ txHeaderView $ case txList !! (txPagination - 1) of
-                                                            Nothing -> mkTxHeaderViewProps mkEmptyProps
+                                      [ txHeaderView $ case currentTxBrief of
+                                                            Nothing -> mkTxHeaderViewProps mkEmptyViewProps
                                                             Just txBrief -> mkTxHeaderViewProps txBrief
-                                      , transactionBodyView state
+                                      , transactionBodyView $ case currentTxBrief of
+                                                                  Nothing -> mkTxBodyViewProps mkEmptyViewProps
+                                                                  Just txBrief -> mkTxBodyViewProps txBrief
                                       , transactionPaginationView
                                             { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
-                                            , currentPage: 1
-                                            , maxPage: (length txList) + 1
+                                            , currentPage: txPagination
+                                            , maxPage: length txList
                                             , changePageAction: AddressPaginateTxs
                                             , onFocusAction: SelectInputText <<< targetToHTMLInputElement
                                             }
@@ -112,7 +109,6 @@ type SummaryRowItem =
     { label :: String
     , value :: String
     , currency :: Maybe CCurrency
-    , link :: Maybe String
     }
 
 type SummaryItems = Array SummaryRowItem
@@ -122,17 +118,14 @@ addressDetailRowItems (CAddressSummary address) lang =
     [ { label: translate (I18nL.common <<< I18nL.cAddress) lang
       , value: address ^. (caAddress <<< _CAddress)
       , currency: Nothing
-      , link: Just <<< toUrl <<< Address $ address ^. caAddress
     }
     , { label: translate (I18nL.common <<< I18nL.cTransactions) lang
       , value: show $ address ^. caTxNum
       , currency: Nothing
-      , link: Nothing
     }
     , { label: translate (I18nL.address <<< I18nL.addFinalBalance) lang
       , value: show $ address ^. (caBalance <<< _Coin <<< getCoin)
       , currency: Just ADA
-      , link: Nothing
       }
     ]
 
@@ -145,12 +138,5 @@ addressDetailRow item =
             [ P.text item.label ]
         , P.div
               [ P.className $ "address-detail__column amount" <> currencyCSSClass item.currency ]
-              [ case item.link of
-                    Nothing ->
-                        P.text item.value
-                    Just link ->
-                        P.link link
-                            [ P.className "link" ]
-                            [ P.text item.value ]
-              ]
+              [ P.text item.value ]
         ]

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -40,7 +40,6 @@ addressView state =
                               [ addressDetailView addressSummary lang'
                               , addressQr addressSummary lang'
                               ]
-
                       ]
                   ]
             , P.div

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -11,8 +11,7 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.Util.Factory (mkCTxEntryFrom, mkEmptyCTxEntry)
-import Explorer.View.Common (currencyCSSClass, transactionBodyView, transactionHeaderView, transactionPaginationView)
+import Explorer.View.Common (currencyCSSClass, mkEmptyProps, mkTxHeaderViewProps, transactionBodyView, txHeaderView, transactionPaginationView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CAddressSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxList, caTxNum)
@@ -65,9 +64,9 @@ addressView state =
                                   in
                                   P.div
                                       []
-                                      [ transactionHeaderView $ case txList !! (txPagination - 1) of
-                                                                Nothing -> mkEmptyCTxEntry
-                                                                Just txBrief -> mkCTxEntryFrom txBrief
+                                      [ txHeaderView $ case txList !! (txPagination - 1) of
+                                                            Nothing -> mkTxHeaderViewProps mkEmptyProps
+                                                            Just txBrief -> mkTxHeaderViewProps txBrief
                                       , transactionBodyView state
                                       , transactionPaginationView
                                             { label: translate (I18nL.common <<< I18nL.cOf) $ lang'

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -5,16 +5,16 @@ import Data.Lens ((^.))
 import Data.Maybe (Maybe(..))
 import Explorer.I18n.Lang (Language, translate)
 import Explorer.I18n.Lenses (cBlock, common, cOf, cNotAvailable, block, blFees, blRoot, blNextBlock, blPrevBlock, blEstVolume, cHash, cSummary, cTotalOutput, cHashes, cHeight, cTransactions) as I18nL
-import Explorer.Lenses.State (lang, currentBlock)
+import Explorer.Lenses.State (currentBlockSummary, lang)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
 import Explorer.Util.Factory (mkEmptyCTxEntry)
 import Explorer.View.Common (currencyCSSClass, transactionPaginationView, transactionHeaderView, transactionBodyView)
+import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeHeight, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
-import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pux.Html (Html, div, text, h3) as P
 import Pux.Html.Attributes (className) as P
 import Pux.Router (link) as P
@@ -32,7 +32,7 @@ blockView state =
                   [ P.h3
                       [ P.className "headline"]
                       [ P.text $ translate (I18nL.common <<< I18nL.cBlock) lang' ]
-                    , blockSummaryView (state ^. currentBlock) lang'
+                    , blockSummaryView (state ^. currentBlockSummary) lang'
                   ]
 
             ]

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -10,7 +10,7 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.View.Common (currencyCSSClass, mkEmptyTxHeaderViewProps, transactionBodyView, txHeaderView, transactionPaginationView)
+import Explorer.View.Common (currencyCSSClass, mkEmptyProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeHeight, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
@@ -43,7 +43,7 @@ blockView state =
                     [ P.className "headline"]
                     [ P.text $ translate (I18nL.common <<< I18nL.cSummary) lang' ]
                 -- TODO (jk) use empty CTxEntry if we'll have real data
-                , txHeaderView mkEmptyTxHeaderViewProps
+                , txHeaderView $ mkTxHeaderViewProps mkEmptyProps
                 , transactionBodyView state
                 , transactionPaginationView paginationViewProps
                 ]

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -10,7 +10,7 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.View.Common (currencyCSSClass, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
+import Explorer.View.Common (currencyCSSClass, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txPaginationView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeHeight, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
@@ -44,8 +44,8 @@ blockView state =
                     [ P.text $ translate (I18nL.common <<< I18nL.cSummary) lang' ]
                 -- TODO (jk) use empty CTxEntry if we'll have real data
                 , txHeaderView $ mkTxHeaderViewProps mkEmptyViewProps
-                , transactionBodyView $ mkTxBodyViewProps mkEmptyViewProps
-                , transactionPaginationView paginationViewProps
+                , txBodyView $ mkTxBodyViewProps mkEmptyViewProps
+                , txPaginationView paginationViewProps
                 ]
             ]
         ]

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -10,7 +10,7 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.View.Common (currencyCSSClass, mkEmptyProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
+import Explorer.View.Common (currencyCSSClass, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, transactionBodyView, transactionPaginationView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeHeight, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
@@ -43,8 +43,8 @@ blockView state =
                     [ P.className "headline"]
                     [ P.text $ translate (I18nL.common <<< I18nL.cSummary) lang' ]
                 -- TODO (jk) use empty CTxEntry if we'll have real data
-                , txHeaderView $ mkTxHeaderViewProps mkEmptyProps
-                , transactionBodyView state
+                , txHeaderView $ mkTxHeaderViewProps mkEmptyViewProps
+                , transactionBodyView $ mkTxBodyViewProps mkEmptyViewProps
                 , transactionPaginationView paginationViewProps
                 ]
             ]

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -10,8 +10,7 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
-import Explorer.Util.Factory (mkEmptyCTxEntry)
-import Explorer.View.Common (currencyCSSClass, transactionPaginationView, transactionHeaderView, transactionBodyView)
+import Explorer.View.Common (currencyCSSClass, mkEmptyTxHeaderViewProps, transactionBodyView, txHeaderView, transactionPaginationView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeHeight, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
@@ -44,7 +43,7 @@ blockView state =
                     [ P.className "headline"]
                     [ P.text $ translate (I18nL.common <<< I18nL.cSummary) lang' ]
                 -- TODO (jk) use empty CTxEntry if we'll have real data
-                , transactionHeaderView mkEmptyCTxEntry
+                , txHeaderView mkEmptyTxHeaderViewProps
                 , transactionBodyView state
                 , transactionPaginationView paginationViewProps
                 ]

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -24,7 +24,7 @@ import Data.Tuple (Tuple(..))
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
-import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
+import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin, sumCoinOfInputsOutputs)
 import Explorer.View.Lenses (txbInputs, txbOutputs, txhAmount, txhHash, txhTimeIssued)
 import Exporer.View.Types (TxBodyViewProps(..), TxHeaderViewProps(..))
 import Pos.Core.Lenses.Types (_Coin, getCoin)
@@ -57,7 +57,7 @@ instance cTxBriefTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxBrief w
     mkTxHeaderViewProps (CTxBrief txBrief) = TxHeaderViewProps
         { txhHash: txBrief ^. ctbId
         , txhTimeIssued: Just $ txBrief ^. ctbTimeIssued
-        , txhAmount: mkCoin 0 -- TODO(jk) We do need an amount here
+        , txhAmount: sumCoinOfInputsOutputs $ txBrief ^. ctbOutputs
         }
 
 -- | Creates a TxHeaderViewProps by a given CTxSummary

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -2,15 +2,16 @@ module Explorer.View.Common (
     placeholderView
     , txHeaderView
     , transactionBodyView
-    , transactionBodyView'
     , emptyTxHeaderView
     , mkTxHeaderViewProps
     , class TxHeaderViewPropsFactory
+    , mkTxBodyViewProps
+    , class TxBodyViewPropsFactory
     , currencyCSSClass
     , paginationView
     , transactionPaginationView
-    , EmptyProps
-    , mkEmptyProps
+    , EmptyViewProps
+    , mkEmptyViewProps
     , noData
     ) where
 
@@ -24,25 +25,20 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
-import Explorer.View.Lenses (txhAmount, txhHash, txhTimeIssued)
-import Exporer.View.Types (TxHeaderViewProps(..))
+import Explorer.View.Lenses (txbInputs, txbOutputs, txhAmount, txhHash, txhTimeIssued)
+import Exporer.View.Types (TxBodyViewProps(..), TxHeaderViewProps(..))
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Core.Types (Coin(..))
 import Pos.Explorer.Web.ClientTypes (CAddress(..), CTxBrief(..), CTxEntry(..), CTxSummary(..))
-import Pos.Explorer.Web.Lenses.ClientTypes (_CHash, _CTxId, ctbId, ctbTimeIssued, cteId, cteTimeIssued, ctsBlockTimeIssued, ctsId, ctsInputs, ctsOutputs, ctsTotalOutput)
-import Pux.Html (Html, text, div, a, p, span, input) as P
-import Pux.Html.Attributes (className, href, value, disabled, type_, min, max) as P
+import Pos.Explorer.Web.Lenses.ClientTypes (_CHash, _CTxId, ctbId, ctbInputs, ctbOutputs, ctbTimeIssued, cteId, cteTimeIssued, ctsBlockTimeIssued, ctsId, ctsInputs, ctsOutputs, ctsTotalOutput)
+import Pux.Html (Html, text, div, p, span, input) as P
+import Pux.Html.Attributes (className, value, disabled, type_, min, max) as P
 import Pux.Html.Events (onChange, onFocus, FormEvent, MouseEvent, Target, onClick) as P
 import Pux.Router (link) as P
 
--- transactions
-
-
-emptyTxHeaderView :: State -> P.Html Action
-emptyTxHeaderView _ =
-    P.div
-        [ P.className "transaction-header"]
-        [ ]
+-- -----------------
+-- tx header
+-- -----------------
 
 -- | Factory to create TxHeaderViewProps by a given type
 class TxHeaderViewPropsFactory a where
@@ -51,46 +47,40 @@ class TxHeaderViewPropsFactory a where
 -- | Creates a TxHeaderViewProps by a given CTxEntry
 instance cTxEntryTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxEntry where
     mkTxHeaderViewProps (CTxEntry entry) = TxHeaderViewProps
-      { txhHash: entry ^. cteId
-      , txhTimeIssued: Just $ entry ^. cteTimeIssued
-      , txhAmount: entry . cteAmount
-      }
+        { txhHash: entry ^. cteId
+        , txhTimeIssued: Just $ entry ^. cteTimeIssued
+        , txhAmount: entry . cteAmount
+        }
 
 -- | Creates a TxHeaderViewProps by a given CTxBrief
 instance cTxBriefTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxBrief where
     mkTxHeaderViewProps (CTxBrief txBrief) = TxHeaderViewProps
-      { txhHash: txBrief ^. ctbId
-      , txhTimeIssued: Just $ txBrief ^. ctbTimeIssued
-      , txhAmount: mkCoin 0 -- TODO(jk) We do need an amount here
-      }
+        { txhHash: txBrief ^. ctbId
+        , txhTimeIssued: Just $ txBrief ^. ctbTimeIssued
+        , txhAmount: mkCoin 0 -- TODO(jk) We do need an amount here
+        }
 
 -- | Creates a TxHeaderViewProps by a given CTxSummary
 instance cTxSummaryTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxSummary where
     mkTxHeaderViewProps (CTxSummary txSummary) = TxHeaderViewProps
-      { txhHash: txSummary ^. ctsId
-      , txhTimeIssued: txSummary ^. ctsBlockTimeIssued
-      , txhAmount: txSummary ^. ctsTotalOutput
-      }
+        { txhHash: txSummary ^. ctsId
+        , txhTimeIssued: txSummary ^. ctsBlockTimeIssued
+        , txhAmount: txSummary ^. ctsTotalOutput
+        }
 
--- | Creates a TxHeaderViewProps by a given EmptyProps
-instance mTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory EmptyProps where
+-- | Creates a TxHeaderViewProps by a given EmptyViewProps
+instance emtpyTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory EmptyViewProps where
     mkTxHeaderViewProps _ = TxHeaderViewProps
         { txhHash: mkCTxId noData
         , txhTimeIssued: Nothing
         , txhAmount: mkCoin 0
         }
 
-newtype EmptyProps = EmptyProps {}
-
-mkEmptyProps :: EmptyProps
-mkEmptyProps = EmptyProps {}
-
 txHeaderView :: TxHeaderViewProps -> P.Html Action
 txHeaderView (TxHeaderViewProps props) =
     P.div
           [ P.className "transaction-header"]
-          [ P.link
-              (toUrl Dashboard )
+          [ P.link (toUrl <<< Tx $ props ^. txhHash)
               [ P.className "hash" ]
               [ P.text $ props ^. (txhHash <<< _CTxId <<< _CHash) ]
           , P.div
@@ -107,87 +97,70 @@ txHeaderView (TxHeaderViewProps props) =
               ]
           ]
 
-transactionBodyView :: State -> P.Html Action
-transactionBodyView state =
+emptyTxHeaderView :: State -> P.Html Action
+emptyTxHeaderView _ =
     P.div
-        [ P.className "transaction-body" ]
-        [ P.div
-          [ P.className "from-hash-container" ]
-          [ P.a
-              [ P.className "from-hash", P.href "#" ]
-              [ P.text "zrVjWkH9pgc9Ng13dXD6C4KQVqnZGFTmuZ" ]
-          ]
-        , P.div
-              [ P.className "to-hash-container bg-transaction-arrow" ]
-              [ P.link (toUrl <<< Address $ mkCAddress "1NPj2Y8yswHLuw8Yr1FDdobKAW6WVkUZy9")
-                    [ P.className "to-hash"]
-                    [ P.text "1NPj2Y8yswHLuw8Yr1FDdobKAW6WVkUZy9" ]
-              , P.link (toUrl <<< Address $ mkCAddress "1NPj2Y8yswHLuw8Yr1FDdobKasdfadsfaf")
-                    [ P.className "to-hash"]
-                    [ P.text "1NPj2Y8yswHLuw8Yr1FDdobKasdfadsfaf" ]
-              , P.link (toUrl <<< Address $ mkCAddress "1NPj2Y8yswHLuw8Yr1FDdobKasdfadsfaf")
-                    [ P.className "to-hash"]
-                    [ P.text "1NPj2Y8yswHLuw8Yr1FDdobKasdfadsfaf" ]
-              ]
-        , P.div
-              [ P.className "to-alias-container" ]
-              [ P.p
-                  [ P.className "to-alias" ]
-                  [ P.text "to red" ]
-              , P.p
-                  [ P.className "to-alias" ]
-                  [ P.text "to blue" ]
-              , P.p
-                  [ P.className "to-alias" ]
-                  [ P.text "to grey" ]
-              ]
-        , P.div
-              [ P.className "amount-container" ]
-              [ P.span
-                  [ P.className "amount bg-ada-dark" ]
-                  [ P.text "131,100"]
-              ]
-        ]
+        [ P.className "transaction-header"]
+        [ ]
+-- -----------------
+-- tx body
+-- -----------------
 
-transactionBodyView' :: CTxSummary -> P.Html Action
-transactionBodyView' (CTxSummary txSummary) =
+-- | Factory to create TxBodyViewProps by a given type
+class TxBodyViewPropsFactory a where
+    mkTxBodyViewProps :: a -> TxBodyViewProps
+
+-- | Creates a TxBodyViewProps by a given CTxSummary
+instance cTxSummaryTxBodyViewPropsFactory :: TxBodyViewPropsFactory CTxSummary where
+    mkTxBodyViewProps (CTxSummary txSummary) = TxBodyViewProps
+        { txbInputs: txSummary ^. ctsInputs
+        , txbOutputs: txSummary ^. ctsOutputs
+        }
+
+-- | Creates a TxBodyViewProps by a given CTxBrief
+instance cTxBriefTxBodyViewPropsFactory :: TxBodyViewPropsFactory CTxBrief where
+    mkTxBodyViewProps (CTxBrief txBrief) = TxBodyViewProps
+        { txbInputs: txBrief ^. ctbInputs
+        , txbOutputs: txBrief ^. ctbOutputs
+        }
+
+-- | Creates a TxBodyViewProps by a given EmptyViewProps
+instance emptyTxBodyViewPropsFactory :: TxBodyViewPropsFactory EmptyViewProps where
+    mkTxBodyViewProps _ = TxBodyViewProps
+        { txbInputs: []
+        , txbOutputs: []
+        }
+
+transactionBodyView :: TxBodyViewProps -> P.Html Action
+transactionBodyView (TxBodyViewProps props) =
     P.div
         [ P.className "transaction-body" ]
         [ P.div
             [ P.className "from-hash-container" ]
-            <<< map transactionFromView $ txSummary ^. ctsInputs
+            <<< map txFromView $ props ^. txbInputs
         , P.div
             [ P.className "to-hash-container bg-transaction-arrow" ]
-            <<< map transactionToView $ txSummary ^. ctsOutputs
-        , P.div
-            [ P.className "to-alias-container" ]
-            <<< map transactionAliasView $ txSummary ^. ctsOutputs
+            <<< map txToView $ props ^. txbOutputs
         , P.div
               [ P.className "amount-container" ]
-              <<< map transactionCoinView $ txSummary ^. ctsOutputs
+              <<< map txAmountView $ props ^. txbOutputs
         ]
 
 
-transactionFromView :: Tuple CAddress Coin -> P.Html Action
-transactionFromView (Tuple (CAddress cAddress) _) =
+txFromView :: Tuple CAddress Coin -> P.Html Action
+txFromView (Tuple (CAddress cAddress) _) =
     P.link (toUrl <<< Address $ mkCAddress cAddress)
         [ P.className "from-hash" ]
         [ P.text cAddress ]
 
-transactionToView :: Tuple CAddress Coin -> P.Html Action
-transactionToView (Tuple (CAddress cAddress) _) =
+txToView :: Tuple CAddress Coin -> P.Html Action
+txToView (Tuple (CAddress cAddress) _) =
     P.link (toUrl <<< Address $ mkCAddress cAddress)
           [ P.className "to-hash"]
           [ P.text cAddress ]
 
-transactionAliasView :: Tuple CAddress Coin -> P.Html Action
-transactionAliasView (Tuple (CAddress cAddress) (Coin coin)) =
-    P.p
-        [ P.className "to-alias" ]
-        [ P.text "to red" ]
-
-transactionCoinView :: Tuple CAddress Coin -> P.Html Action
-transactionCoinView (Tuple _ (Coin coin)) =
+txAmountView :: Tuple CAddress Coin -> P.Html Action
+txAmountView (Tuple _ (Coin coin)) =
     P.div
         [ P.className "amount-wrapper" ]
         [ P.span
@@ -195,7 +168,9 @@ transactionCoinView (Tuple _ (Coin coin)) =
             [ P.text <<< show $ coin ^. getCoin ]
         ]
 
+-- -----------------
 -- pagination
+-- -----------------
 
 type PaginationViewProps =
     { label :: String
@@ -279,7 +254,14 @@ paginationView props =
               else NoOp
 
 
+-- -----------------
 -- helper
+-- -----------------
+
+newtype EmptyViewProps = EmptyViewProps {}
+
+mkEmptyViewProps :: EmptyViewProps
+mkEmptyViewProps = EmptyViewProps {}
 
 noData :: String
 noData = "--"

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -1,7 +1,7 @@
 module Explorer.View.Common (
     placeholderView
     , txHeaderView
-    , transactionBodyView
+    , txBodyView
     , emptyTxHeaderView
     , mkTxHeaderViewProps
     , class TxHeaderViewPropsFactory
@@ -9,7 +9,7 @@ module Explorer.View.Common (
     , class TxBodyViewPropsFactory
     , currencyCSSClass
     , paginationView
-    , transactionPaginationView
+    , txPaginationView
     , EmptyViewProps
     , mkEmptyViewProps
     , noData
@@ -131,8 +131,8 @@ instance emptyTxBodyViewPropsFactory :: TxBodyViewPropsFactory EmptyViewProps wh
         , txbOutputs: []
         }
 
-transactionBodyView :: TxBodyViewProps -> P.Html Action
-transactionBodyView (TxBodyViewProps props) =
+txBodyView :: TxBodyViewProps -> P.Html Action
+txBodyView (TxBodyViewProps props) =
     P.div
         [ P.className "transaction-body" ]
         [ P.div
@@ -180,8 +180,8 @@ type PaginationViewProps =
     , onFocusAction :: (P.Target -> Action)
     }
 
-transactionPaginationView :: PaginationViewProps -> P.Html Action
-transactionPaginationView props =
+txPaginationView :: PaginationViewProps -> P.Html Action
+txPaginationView props =
     P.div
         [ P.className "transaction-pagination"]
         [ paginationView props ]

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -5,7 +5,6 @@ module Explorer.View.Common (
     , transactionBodyView'
     , emptyTxHeaderView
     , mkTxHeaderViewProps
-    , mkEmptyTxHeaderViewProps
     , class TxHeaderViewPropsFactory
     , currencyCSSClass
     , paginationView
@@ -73,7 +72,7 @@ instance cTxSummaryTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxSumma
       , txhAmount: txSummary ^. ctsTotalOutput
       }
 
--- | Creates a TxHeaderViewProps by a given CTxSummary
+-- | Creates a TxHeaderViewProps by a given EmptyProps
 instance mTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory EmptyProps where
     mkTxHeaderViewProps _ = TxHeaderViewProps
         { txhHash: mkCTxId noData
@@ -85,14 +84,6 @@ newtype EmptyProps = EmptyProps {}
 
 mkEmptyProps :: EmptyProps
 mkEmptyProps = EmptyProps {}
-
--- | Creates an empty TxHeaderViewProps
-mkEmptyTxHeaderViewProps :: TxHeaderViewProps
-mkEmptyTxHeaderViewProps = TxHeaderViewProps
-    { txhHash: mkCTxId noData
-    , txhTimeIssued: Nothing
-    , txhAmount: mkCoin 0
-    }
 
 txHeaderView :: TxHeaderViewProps -> P.Html Action
 txHeaderView (TxHeaderViewProps props) =
@@ -110,9 +101,8 @@ txHeaderView (TxHeaderViewProps props) =
               ]
           , P.div
               [ P.className "amount-container" ]
-              [ P.a
-                  [ P.className "amount bg-ada"
-                  , P.href "#" ]
+              [ P.div
+                  [ P.className "amount bg-ada" ]
                   [ P.text <<< show $ props ^. (txhAmount <<< _Coin <<< getCoin) ]
               ]
           ]

--- a/frontend/src/Explorer/View/Transaction.purs
+++ b/frontend/src/Explorer/View/Transaction.purs
@@ -9,7 +9,7 @@ import Explorer.I18n.Lenses (common, cTransaction, cTransactionFeed, cSummary, t
 import Explorer.Lenses.State (currentTxSummary, lang)
 import Explorer.Types.Actions (Action)
 import Explorer.Types.State (CCurrency(..), State)
-import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxHeaderViewProps, noData, transactionBodyView', txHeaderView)
+import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxBodyViewProps, mkTxHeaderViewProps, noData, transactionBodyView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CTxSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CNetworkAddress, ctsBlockHeight, ctsFees, ctsRelayedBy, ctsTotalOutput, ctsTxTimeIssued)
@@ -35,7 +35,7 @@ transactionView state =
                             P.div
                                 []
                                 [ txHeaderView $ mkTxHeaderViewProps txSummary
-                                , transactionBodyView' txSummary
+                                , transactionBodyView $ mkTxBodyViewProps txSummary
                                 ]
                 ]
             ]

--- a/frontend/src/Explorer/View/Transaction.purs
+++ b/frontend/src/Explorer/View/Transaction.purs
@@ -9,7 +9,7 @@ import Explorer.I18n.Lenses (common, cTransaction, cTransactionFeed, cSummary, t
 import Explorer.Lenses.State (currentTxSummary, lang)
 import Explorer.Types.Actions (Action)
 import Explorer.Types.State (CCurrency(..), State)
-import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxBodyViewProps, mkTxHeaderViewProps, noData, transactionBodyView, txHeaderView)
+import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxBodyViewProps, mkTxHeaderViewProps, noData, txBodyView, txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CTxSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CNetworkAddress, ctsBlockHeight, ctsFees, ctsRelayedBy, ctsTotalOutput, ctsTxTimeIssued)
@@ -35,7 +35,7 @@ transactionView state =
                             P.div
                                 []
                                 [ txHeaderView $ mkTxHeaderViewProps txSummary
-                                , transactionBodyView $ mkTxBodyViewProps txSummary
+                                , txBodyView $ mkTxBodyViewProps txSummary
                                 ]
                 ]
             ]

--- a/frontend/src/Explorer/View/Transaction.purs
+++ b/frontend/src/Explorer/View/Transaction.purs
@@ -9,7 +9,7 @@ import Explorer.I18n.Lenses (common, cTransaction, cTransactionFeed, cSummary, t
 import Explorer.Lenses.State (currentTxSummary, lang)
 import Explorer.Types.Actions (Action)
 import Explorer.Types.State (CCurrency(..), State)
-import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, transactionBodyView', transactionHeaderView')
+import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxHeaderViewProps, noData, transactionBodyView', txHeaderView)
 import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CTxSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CNetworkAddress, ctsBlockHeight, ctsFees, ctsRelayedBy, ctsTotalOutput, ctsTxTimeIssued)
@@ -34,7 +34,7 @@ transactionView state =
                         Just txSummary ->
                             P.div
                                 []
-                                [ transactionHeaderView' txSummary
+                                [ txHeaderView $ mkTxHeaderViewProps txSummary
                                 , transactionBodyView' txSummary
                                 ]
                 ]
@@ -56,9 +56,6 @@ transactionView state =
                 ]
             ]
         ]
-
-noData :: String
-noData = "--"
 
 type SummaryItems = Array SummaryItem
 

--- a/frontend/src/Explorer/View/Types.purs
+++ b/frontend/src/Explorer/View/Types.purs
@@ -1,0 +1,13 @@
+module Exporer.View.Types where
+
+import Data.Maybe (Maybe)
+import Data.Time.NominalDiffTime (NominalDiffTime)
+import Pos.Core.Types (Coin)
+import Pos.Explorer.Web.ClientTypes (CTxId)
+
+
+newtype TxHeaderViewProps = TxHeaderViewProps
+  { txhHash :: CTxId
+  , txhTimeIssued :: Maybe NominalDiffTime
+  , txhAmount :: Coin
+  }

--- a/frontend/src/Explorer/View/Types.purs
+++ b/frontend/src/Explorer/View/Types.purs
@@ -2,12 +2,20 @@ module Exporer.View.Types where
 
 import Data.Maybe (Maybe)
 import Data.Time.NominalDiffTime (NominalDiffTime)
+import Data.Tuple (Tuple)
 import Pos.Core.Types (Coin)
-import Pos.Explorer.Web.ClientTypes (CTxId)
+import Pos.Explorer.Web.ClientTypes (CAddress, CTxId)
 
+-- put all view related types here in this file to generate lenses from it
 
 newtype TxHeaderViewProps = TxHeaderViewProps
   { txhHash :: CTxId
   , txhTimeIssued :: Maybe NominalDiffTime
   , txhAmount :: Coin
+  }
+
+
+newtype TxBodyViewProps = TxBodyViewProps
+  { txbInputs :: Array (Tuple CAddress Coin)
+  , txbOutputs :: Array (Tuple CAddress Coin)
   }

--- a/frontend/src/Explorer/View/common.css
+++ b/frontend/src/Explorer/View/common.css
@@ -34,14 +34,11 @@
   .amount {
     box-item: center;
 
-    color: var(--color0);
-
     padding: 5px 10px 5px 20px;
-
-    button: primary-button;
+    color: var(--color0);
     border-radius: 4px;
 
-
+    background-color: var(--color10);
     background-repeat: no-repeat;
     background-position: 7px center;
     background-size: 8px 7px;

--- a/frontend/src/Explorer/View/common.css
+++ b/frontend/src/Explorer/View/common.css
@@ -16,6 +16,8 @@
     @neat-span-columns 8;
     color: var(--color8);
     line-height: var(--transaction-header-height);
+    button: standard-button;
+    button-color: var(--color8) color(var(--color5) a(0.8)) var(--color5);
   }
 
   .date {
@@ -65,7 +67,7 @@
   }
 
   .to-hash-container {
-    @neat-span-columns 4;
+    @neat-span-columns 5;
 
     background-repeat: no-repeat;
     background-position: left center;
@@ -83,19 +85,8 @@
     padding-bottom: 12px;
   }
 
-  .to-alias-container {
-    @neat-span-columns 2;
-    padding: 18px 0 0 0;
-    box-item: center;
-  }
-
-  .to-alias {
-    padding-bottom: 12px;
-    padding-left: 15px;
-  }
-
   .amount-container {
-    @neat-span-columns 2;
+    @neat-span-columns 3;
     padding: 18px 0 0 0;
     text-align: right;
     box-item: center;

--- a/frontend/src/Main.Test.purs
+++ b/frontend/src/Main.Test.purs
@@ -2,12 +2,14 @@ module Main.Test where
 
 import Prelude
 import Control.Monad.Eff (Eff)
-import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (RunnerEffects, run)
+import Explorer.Util.Factory.Test (testFactoryUtil)
 import Explorer.Util.String.Test (testStringUtil)
 import Explorer.Util.Time.Test (testPrettyDuration)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner (RunnerEffects, run)
 
 main :: Eff (RunnerEffects ()) Unit
 main = run [consoleReporter] do
     testStringUtil
     testPrettyDuration
+    testFactoryUtil

--- a/frontend/src/Main.purs
+++ b/frontend/src/Main.purs
@@ -28,11 +28,11 @@ config state = do
   -- socket
   actionChannel <- channel $ Ex.SocketConnected false
   let socketSignal = subscribe actionChannel :: Signal Ex.Action
-  socket <- connect Ex.socketHost
-  on socket Ex.connectEvent $ Ex.connectHandler actionChannel
-  on socket Ex.closeEvent $ Ex.closeHandler actionChannel
-  on socket Ex.lastestBlocksEvent $ Ex.latestBlocksHandler actionChannel
-  on socket Ex.lastestTransactionsEvent $ Ex.latestTransactionsHandler actionChannel
+  -- socket <- connect Ex.socketHost
+  -- on socket Ex.connectEvent $ Ex.connectHandler actionChannel
+  -- on socket Ex.closeEvent $ Ex.closeHandler actionChannel
+  -- on socket Ex.lastestBlocksEvent $ Ex.latestBlocksHandler actionChannel
+  -- on socket Ex.lastestTransactionsEvent $ Ex.latestTransactionsHandler actionChannel
 
   pure
     { initialState: state


### PR DESCRIPTION
This pull request includes the full implementation of `address summary` endpoint. It also provides general view components (`txHeaderView`, `txBodyView`) to display transaction details everywhere by using same views (`block detail page`, `address detail page`, `transaction detail page`)