### PR TITLE
Feature/csm180 fix block txs

### DIFF
--- a/frontend/src/Explorer/Api/Http.purs
+++ b/frontend/src/Explorer/Api/Http.purs
@@ -11,7 +11,7 @@ import Data.HTTP.Method (Method(..))
 import Data.Lens ((^.))
 import Explorer.Api.Helper (decodeResult)
 import Explorer.Api.Types (EndpointError(..), Endpoint)
-import Explorer.Types.State (CBlockEntries, CTxEntries)
+import Explorer.Types.State (CBlockEntries, CTxEntries, CTxBriefs)
 import Network.HTTP.Affjax (AJAX, AffjaxRequest, affjax, defaultRequest)
 import Network.HTTP.Affjax.Request (class Requestable)
 import Network.HTTP.StatusCode (StatusCode(..))
@@ -52,7 +52,7 @@ fetchLatestBlocks = get "blocks/last"
 fetchBlockSummary :: forall eff. CHash -> Aff (ajax::AJAX | eff) CBlockSummary
 fetchBlockSummary (CHash hash) = get $ "blocks/summary/" <> hash
 
-fetchBlockTxs :: forall eff. CHash -> Aff (ajax::AJAX | eff) CTxEntries
+fetchBlockTxs :: forall eff. CHash -> Aff (ajax::AJAX | eff) CTxBriefs
 fetchBlockTxs (CHash hash) = get $ "blocks/txs/" <> hash
 
 -- txs

--- a/frontend/src/Explorer/Types/Actions.purs
+++ b/frontend/src/Explorer/Types/Actions.purs
@@ -1,13 +1,15 @@
 module Explorer.Types.Actions where
 
-import Control.Monad.Eff.Exception (Error)
-import DOM.HTML.Types (HTMLInputElement)
-import Data.Either (Either)
-import Explorer.I18n.Lang (Language)
-import Explorer.Routes (Route)
-import Explorer.Types.State (DashboardAPICode, CBlockEntries, CTxEntries)
-import Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary, CBlockSummary, CHash, CTxId, CTxSummary)
-import Signal.Channel (Channel)
+import           Control.Monad.Eff.Exception  (Error)
+import           Data.Either                  (Either)
+import           DOM.HTML.Types               (HTMLInputElement)
+import           Explorer.I18n.Lang           (Language)
+import           Explorer.Routes              (Route)
+import           Explorer.Types.State         (CBlockEntries, CTxBriefs, CTxEntries,
+                                               DashboardAPICode)
+import           Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary, CBlockSummary,
+                                               CHash, CTxId, CTxSummary)
+import           Signal.Channel               (Channel)
 
 data Action
     = SetLanguage Language
@@ -28,7 +30,7 @@ data Action
     | RequestBlockSummary CHash
     | ReceiveBlockSummary (Either Error CBlockSummary)
     | RequestBlockTxs CHash
-    | ReceiveBlockTxs (Either Error CTxEntries)
+    | ReceiveBlockTxs (Either Error CTxBriefs)
     | RequestInitialTxs
     | ReceiveInitialTxs (Either Error CTxEntries)
     | RequestTxSummary CTxId

--- a/frontend/src/Explorer/Types/State.purs
+++ b/frontend/src/Explorer/Types/State.purs
@@ -3,7 +3,7 @@ module Explorer.Types.State where
 import Data.Maybe (Maybe)
 import Explorer.I18n.Lang (Language)
 import Explorer.Routes (Route)
-import Pos.Explorer.Web.ClientTypes (CAddressSummary, CBlockEntry, CBlockSummary, CTxEntry, CTxSummary)
+import Pos.Explorer.Web.ClientTypes (CAddressSummary, CBlockEntry, CBlockSummary, CTxEntry, CTxSummary, CTxBrief)
 import Prelude (class Eq, class Ord)
 
 -- Add all State types here to generate lenses from it
@@ -19,7 +19,7 @@ type State =
     , initialTxsRequested :: Boolean
     , handleLatestTxsSocketResult :: Boolean
     , currentBlockSummary :: Maybe CBlockSummary
-    , currentBlockTxs :: CTxEntries
+    , currentBlockTxs :: CTxBriefs
     , currentTxSummary :: Maybe CTxSummary
     , latestTransactions :: CTxEntries
     , currentAddressSummary :: Maybe CAddressSummary
@@ -38,6 +38,7 @@ derive instance ordDashboardAPICode :: Ord DashboardAPICode
 
 type CBlockEntries = Array CBlockEntry
 type CTxEntries = Array CTxEntry
+type CTxBriefs = Array CTxBrief
 
 type Errors = Array String
 

--- a/src/Pos/Explorer/Web/Api.hs
+++ b/src/Pos/Explorer/Web/Api.hs
@@ -10,10 +10,10 @@ module Pos.Explorer.Web.Api
 
 import           Data.Proxy                   (Proxy (Proxy))
 
-import           Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary,
-                                               CBlockEntry, CBlockSummary,
-                                               CSearchId, CHash, CTxEntry, CTxId,
-                                               CTxSummary, CHashSearchResult)
+import           Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary, CBlockEntry,
+                                               CBlockSummary, CHash, CHashSearchResult,
+                                               CSearchId, CTxBrief, CTxEntry, CTxId,
+                                               CTxSummary)
 import           Pos.Explorer.Web.Error       (ExplorerError)
 import           Servant.API                  ((:<|>), (:>), Capture, Get, JSON,
                                                QueryParam)
@@ -40,7 +40,7 @@ type ExplorerApi =
       :> Capture "hash" CHash
       :> QueryParam "limit" Word
       :> QueryParam "offset" Word
-      :> Get '[JSON] (Either ExplorerError [CTxEntry])
+      :> Get '[JSON] (Either ExplorerError [CTxBrief])
     :<|>
       "api"
       :> "txs"

--- a/src/Pos/Explorer/Web/Doc.hs
+++ b/src/Pos/Explorer/Web/Doc.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds         #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}
@@ -16,38 +16,31 @@ import           Control.Lens                   ((<>~))
 import qualified Data.ByteString.Char8          as BSC
 import qualified Data.HashMap.Strict            as HM
 import           Data.String                    as DS
-import           Data.Time                      (defaultTimeLocale,
-                                                 parseTimeOrError)
-import           Data.Time.Clock.POSIX          (POSIXTime,
-                                                 utcTimeToPOSIXSeconds)
+import           Data.Time                      (defaultTimeLocale, parseTimeOrError)
+import           Data.Time.Clock.POSIX          (POSIXTime, utcTimeToPOSIXSeconds)
 import           Pos.Explorer.Aeson.ClientTypes ()
 import           Pos.Explorer.Web.Api           (explorerApi)
-import           Pos.Explorer.Web.ClientTypes   (CAddress (..),
-                                                 CAddressSummary (..),
-                                                 CBlockEntry (..),
-                                                 CBlockSummary (..), CHash (..),
-                                                 CHashSearchResult (..),
-                                                 CSearchId (..), CTxEntry (..),
-                                                 CTxId (..), CTxSummary (..))
+import           Pos.Explorer.Web.ClientTypes   (CAddress (..), CAddressSummary (..),
+                                                 CBlockEntry (..), CBlockSummary (..),
+                                                 CHash (..), CHashSearchResult (..),
+                                                 CSearchId (..), CTxBrief (..),
+                                                 CTxEntry (..), CTxId (..),
+                                                 CTxSummary (..))
 import           Pos.Explorer.Web.Error         (ExplorerError (..))
 import           Pos.Types                      (mkCoin)
 import           Servant.API                    (Capture, QueryParam)
 import           Servant.Docs                   (API, Action, DocCapture (..),
                                                  DocIntro (..), DocNote (..),
                                                  DocQueryParam (..), Endpoint,
-                                                 ExtraInfo (..),
-                                                 ParamKind (Normal),
-                                                 ToCapture (toCapture),
-                                                 ToParam (toParam),
-                                                 ToSample (toSamples),
-                                                 apiEndpoints, apiIntros,
-                                                 capDesc, capSymbol, captures,
+                                                 ExtraInfo (..), ParamKind (Normal),
+                                                 ToCapture (toCapture), ToParam (toParam),
+                                                 ToSample (toSamples), apiEndpoints,
+                                                 apiIntros, capDesc, capSymbol, captures,
                                                  defAction, defEndpoint,
-                                                 defaultDocOptions, docsWith,
-                                                 introBody, introTitle,
-                                                 markdown, method, noteBody,
-                                                 notes, paramDesc, paramName,
-                                                 params, path, pretty)
+                                                 defaultDocOptions, docsWith, introBody,
+                                                 introTitle, markdown, method, noteBody,
+                                                 notes, paramDesc, paramName, params,
+                                                 path, pretty)
 import           Universum
 
 
@@ -186,6 +179,16 @@ instance ToSample CTxEntry where
             { cteId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
             , cteTimeIssued = posixTime
             , cteAmount     = mkCoin 33333
+            }
+
+instance ToSample CTxBrief where
+    toSamples Proxy = [("Sample transaction brief description", sample)]
+      where
+        sample = CTxBrief
+            { ctbId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
+            , ctbTimeIssued = posixTime
+            , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCoin 33333)]
+            , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCoin 33333)]
             }
 
 instance ToSample CTxSummary where

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 - '.'
 - location:
     git: https://github.com/input-output-hk/cardano-sl
-    commit: ec0f6b69de1b506923ba43cfe46b5b11aa828755
+    commit: 0cc55e181ed599f2c57aac9f45e17338b2e7de1b
   extra-dep: true
   subdirs:
       - '.'
@@ -42,7 +42,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 8631647810b950a21735d1466fa72348626213ed
+    commit: 2943e7814b9f78b9ef68c9bdc96820ed32a0fdf3
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
Now endpoint `api/block/txs` returns list of `CTxBrief`, which allows displaying of inputs and outputs of transactions.

I tried to update puresctipt code accordingly, but as I'm unfamiliar with it (and even with building procedures for it) I might have missed something important. So I'd like @sectore to examine my changes carefully and correct my very possible mistakes.