### PR TITLE
[CSM-210] Print socket-io logs with log-warper

### DIFF
--- a/log-config.yaml
+++ b/log-config.yaml
@@ -3,3 +3,5 @@ node:
     plugin:
         notifier:
             severity: Debug
+            socket-io:
+                severity: Debug


### PR DESCRIPTION
This fixes error produced by socket-io server:

> Can't open log file "log/error.log".
> Exception: log/error.log: openFile: does not exist (No such file or directory)
> Logging to stderr instead. **THIS IS BAD, YOU OUGHT TO FIX THIS**
> Can't open log file "log/access.log".
> Exception: log/access.log: openFile: does not exist (No such file or directory)
> Logging to stderr instead. **THIS IS BAD, YOU OUGHT TO FIX THIS**