### PR TITLE
[WIP] [CSE-85] Stringify Coin (wip)

### DIFF
--- a/frontend/scripts/generate-backend-lenses.sh
+++ b/frontend/scripts/generate-backend-lenses.sh
@@ -12,7 +12,6 @@ purescript-derive-lenses \
     --moduleImports "import Data.Maybe" \
     --moduleImports "import Data.Tuple" \
     --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
-    --moduleImports "import Pos.Core.Types (Coin)" \
     > $DIR_GENERATED_WEB/Lenses/ClientTypes.purs
 
 

--- a/frontend/scripts/generate-frontend-lenses.sh
+++ b/frontend/scripts/generate-frontend-lenses.sh
@@ -58,6 +58,5 @@ purescript-derive-lenses \
     --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
     --moduleImports "import Data.Maybe (Maybe)" \
     --moduleImports "import Data.Tuple (Tuple)" \
-    --moduleImports "import Pos.Core.Types (Coin)" \
-    --moduleImports "import Pos.Explorer.Web.ClientTypes (CAddress, CTxId)" \
+    --moduleImports "import Pos.Explorer.Web.ClientTypes (CCoin, CAddress, CTxId)" \
     > $DIR_VIEW_LENSES/View.purs

--- a/frontend/scripts/generate-lenses.sh
+++ b/frontend/scripts/generate-lenses.sh
@@ -14,7 +14,6 @@ purescript-derive-lenses \
     --moduleImports "import Data.Maybe" \
     --moduleImports "import Data.Tuple" \
     --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
-    --moduleImports "import Pos.Core.Types (Coin)" \
     > $DIR_GENERATED_WEB/Lenses/ClientTypes.purs
 
 
@@ -87,6 +86,5 @@ purescript-derive-lenses \
     --moduleImports "import Data.Time.NominalDiffTime (NominalDiffTime(..))" \
     --moduleImports "import Data.Maybe (Maybe)" \
     --moduleImports "import Data.Tuple (Tuple)" \
-    --moduleImports "import Pos.Core.Types (Coin)" \
-    --moduleImports "import Pos.Explorer.Web.ClientTypes (CAddress, CTxId)" \
+    --moduleImports "import Pos.Explorer.Web.ClientTypes (CCoin, CAddress, CTxId)" \
     > $DIR_VIEW_LENSES/View.purs

--- a/frontend/src/Explorer/Util/Factory.Test.purs
+++ b/frontend/src/Explorer/Util/Factory.Test.purs
@@ -6,23 +6,23 @@ import Control.Monad.State (StateT)
 import Data.Identity (Identity)
 import Data.Lens ((^.))
 import Data.Tuple (Tuple(..))
-import Explorer.Util.Factory (mkCAddress, mkCoin, sumCoinOfInputsOutputs)
-import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Explorer.Util.Factory (mkCAddress, mkCoin)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 import Test.Spec (Group, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
-testFactoryUtil :: forall r. StateT (Array (Group (Aff r Unit))) Identity Unit
-testFactoryUtil =
-    describe "Explorer.Util.Factory" do
-        describe "sumCoinOfInputsOutputs" do
-          it "sums a list of Coins"
-            let list =  [ (Tuple (mkCAddress "a") (mkCoin 3))
-                        , (Tuple (mkCAddress "b") (mkCoin 3))
-                        ]
-                coin = sumCoinOfInputsOutputs list
-                result = coin ^. (_Coin <<< getCoin)
-            in result `shouldEqual` 6
-          it "sums an empty list of Coins"
-            let coin = sumCoinOfInputsOutputs []
-                result = coin ^. (_Coin <<< getCoin)
-            in result `shouldEqual` 0
+-- testFactoryUtil :: forall r. StateT (Array (Group (Aff r Unit))) Identity Unit
+-- testFactoryUtil =
+--     describe "Explorer.Util.Factory" do
+--         describe "sumCoinOfInputsOutputs" do
+--           it "sums a list of Coins"
+--             let list =  [ (Tuple (mkCAddress "a") (mkCoin 3))
+--                         , (Tuple (mkCAddress "b") (mkCoin 3))
+--                         ]
+--                 coin = sumCoinOfInputsOutputs list
+--                 result = coin ^. (_Coin <<< getCoin)
+--             in result `shouldEqual` 6
+--           it "sums an empty list of Coins"
+--             let coin = sumCoinOfInputsOutputs []
+--                 result = coin ^. (_Coin <<< getCoin)
+--             in result `shouldEqual` 0

--- a/frontend/src/Explorer/Util/Factory.purs
+++ b/frontend/src/Explorer/Util/Factory.purs
@@ -5,9 +5,9 @@ import Data.Foldable (sum)
 import Data.Lens ((^.))
 import Data.Time.NominalDiffTime (mkTime)
 import Data.Tuple (Tuple(..))
-import Pos.Core.Lenses.Types (_Coin, getCoin)
-import Pos.Core.Types (Coin(..), EpochIndex(..), LocalSlotIndex(..))
-import Pos.Explorer.Web.ClientTypes (CAddress(..), CAddressSummary(..), CHash(..), CTxEntry(..), CTxId(..))
+import Pos.Core.Types (EpochIndex(..), LocalSlotIndex(..))
+import Pos.Explorer.Web.ClientTypes (CCoin(..), CAddress(..), CAddressSummary(..), CHash(..), CTxEntry(..), CTxId(..))
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 
 
 mkCHash :: String -> CHash
@@ -17,9 +17,9 @@ mkCTxId :: String -> CTxId
 mkCTxId =
     CTxId <<< mkCHash
 
-mkCoin :: Int -> Coin
+mkCoin :: Int -> CCoin
 mkCoin coin =
-  Coin {getCoin: coin}
+  CCoin {getCoin: show coin}
 
 mkCAddress :: String -> CAddress
 mkCAddress = CAddress
@@ -29,15 +29,6 @@ mkEpochIndex index = EpochIndex {getEpochIndex: index}
 
 mkLocalSlotIndex :: Int -> LocalSlotIndex
 mkLocalSlotIndex index = LocalSlotIndex {getSlotIndex: index}
-
--- | Helper to summarize coins by a list of Tx inputs or outputs
-sumCoinOfInputsOutputs :: Array (Tuple CAddress Coin) -> Coin
-sumCoinOfInputsOutputs addressList =
-    mkCoin <<< sum $ addressCoins <$> addressList
-      where
-        -- | Get total number of coins from an address
-        addressCoins :: (Tuple CAddress Coin) -> Int
-        addressCoins (Tuple _ coin) = coin ^. (_Coin <<< getCoin)
 
 -- All the following helper function `mkEmpty**` are for debugging only
 -- We do need these to mock live data

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -14,9 +14,8 @@ import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
 import Explorer.View.Common (currencyCSSClass, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
 import Network.RemoteData (RemoteData(..))
-import Pos.Core.Lenses.Types (_Coin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CAddressSummary(..))
-import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxList, caTxNum)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, _CAddress, caAddress, caBalance, caTxList, caTxNum, getCoin)
 import Pux.Html (Html, div, text, h3, p) as P
 import Pux.Html.Attributes (className, dangerouslySetInnerHTML, id_) as P
 import Pux.Router (link) as P
@@ -132,7 +131,7 @@ addressDetailRowItems (CAddressSummary address) lang =
       , currency: Nothing
     }
     , { label: translate (I18nL.address <<< I18nL.addFinalBalance) lang
-      , value: show $ address ^. (caBalance <<< _Coin <<< getCoin)
+      , value: address ^. (caBalance <<< _CCoin <<< getCoin)
       , currency: Just ADA
       }
     ]

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -12,7 +12,7 @@ import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.DOM (targetToHTMLInputElement)
 import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
-import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeSlot, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
 import Pux.Html (Html, div, text, h3) as P
@@ -89,7 +89,7 @@ mkSummaryItems lang (CBlockEntry entry) =
       , currency: Nothing
       }
     , { label: translate (I18nL.common <<< I18nL.cTotalOutput) lang
-      , amount: show $ entry ^. (cbeTotalSent <<< _Coin <<< getCoin)
+      , amount: entry ^. (cbeTotalSent <<< _CCoin <<< getCoin)
       , currency: Just ADA
       }
     , { label: translate (I18nL.block <<< I18nL.blEstVolume) lang

--- a/frontend/src/Explorer/View/Blocks.purs
+++ b/frontend/src/Explorer/View/Blocks.purs
@@ -27,7 +27,7 @@ import Explorer.Util.Time (prettyDuration)
 import Explorer.View.CSS (blocksBody, blocksBodyRow, blocksColumnAge, blocksColumnEpoch, blocksColumnRelayedBy, blocksColumnSize, blocksColumnSlot, blocksColumnTotalSent, blocksColumnTxs, blocksFailed, blocksFooter, blocksHeader) as CSS
 import Explorer.View.Common (getMaxPaginationNumber, noData, paginationView)
 import Network.RemoteData (RemoteData(..))
-import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CBlockEntry(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (cbeBlkHash, cbeEpoch, cbeSlot, cbeRelayedBy, cbeSize, cbeTimeIssued, cbeTotalSent, cbeTxNum)
 import Pux.Html (Html, div, text, h3, p) as P
@@ -136,7 +136,7 @@ blockRow state (CBlockEntry entry) =
         , blockColumn { label: show $ entry ^. cbeTxNum
                       , clazz: CSS.blocksColumnTxs
                       }
-        , blockColumn { label: show $ entry ^. (cbeTotalSent <<< _Coin <<< getCoin)
+        , blockColumn { label: entry ^. (cbeTotalSent <<< _CCoin <<< getCoin)
                       , clazz: CSS.blocksColumnTotalSent
                       }
         , blockColumn { label: labelRelayed

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -32,14 +32,12 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (initialState)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), State)
-import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin, sumCoinOfInputsOutputs)
+import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
 import Explorer.Util.Time (prettyDate)
 import Explorer.View.Lenses (txbAmount, txbInputs, txbOutputs, txhAmount, txhHash, txhTimeIssued)
 import Exporer.View.Types (TxBodyViewProps(..), TxHeaderViewProps(..))
-import Pos.Core.Lenses.Types (getCoin)
-import Pos.Core.Types (Coin(..))
-import Pos.Explorer.Web.ClientTypes (CAddress(..), CTxBrief(..), CTxEntry(..), CTxSummary(..))
-import Pos.Explorer.Web.Lenses.ClientTypes (_CHash, _CTxId, ctbId, ctbInputs, ctbOutputs, ctbTimeIssued, cteId, cteTimeIssued, ctsBlockTimeIssued, ctsId, ctsInputs, ctsOutputs, ctsTotalOutput)
+import Pos.Explorer.Web.ClientTypes (CCoin(..), CAddress(..), CTxBrief(..), CTxEntry(..), CTxSummary(..))
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, _CHash, _CTxId, getCoin, ctbId, ctbInputs, ctbOutputs, ctbInputSum, ctbOutputSum, ctbTimeIssued, cteId, cteTimeIssued, ctsBlockTimeIssued, ctsId, ctsInputs, ctsOutputs, ctsTotalOutput)
 import Pux.Html (Html, text, div, p, span, input, option, select) as P
 import Pux.Html.Attributes (className, href, value, disabled, type_, min, max, selected) as P
 import Pux.Html.Events (onChange, onFocus, FormEvent, MouseEvent, Target, onClick) as P
@@ -66,7 +64,7 @@ instance cTxBriefTxHeaderViewPropsFactory :: TxHeaderViewPropsFactory CTxBrief w
     mkTxHeaderViewProps (CTxBrief txBrief) = TxHeaderViewProps
         { txhHash: txBrief ^. ctbId
         , txhTimeIssued: Just $ txBrief ^. ctbTimeIssued
-        , txhAmount: sumCoinOfInputsOutputs $ txBrief ^. ctbOutputs
+        , txhAmount: txBrief ^. ctbOutputSum
         }
 
 -- | Creates a TxHeaderViewProps by a given CTxSummary
@@ -109,13 +107,13 @@ emptyTxHeaderView =
         [ P.className "transaction-header"]
         [ ]
 
-txAmountView :: Coin -> P.Html Action
-txAmountView (Coin coin) =
+txAmountView :: CCoin -> P.Html Action
+txAmountView (CCoin coin) =
     P.div
         [ P.className "amount-container" ]
         [ P.div
             [ P.className "amount bg-ada" ]
-            [ P.text <<< show $ coin ^. getCoin]
+            [ P.text $ coin ^. getCoin]
         ]
 -- -----------------
 -- tx body
@@ -138,7 +136,7 @@ instance cTxBriefTxBodyViewPropsFactory :: TxBodyViewPropsFactory CTxBrief where
     mkTxBodyViewProps (CTxBrief txBrief) = TxBodyViewProps
         { txbInputs: txBrief ^. ctbInputs
         , txbOutputs: txBrief ^. ctbOutputs
-        , txbAmount: sumCoinOfInputsOutputs $ txBrief ^. ctbOutputs
+        , txbAmount: txBrief ^. ctbOutputSum
         }
 
 -- | Creates a TxBodyViewProps by a given EmptyViewProps
@@ -171,25 +169,25 @@ emptyTxBodyView =
         [ P.className "transaction-body" ]
         []
 
-txFromView :: Tuple CAddress Coin -> P.Html Action
+txFromView :: Tuple CAddress CCoin -> P.Html Action
 txFromView (Tuple (CAddress cAddress) _) =
     P.link (toUrl <<< Address $ mkCAddress cAddress)
         [ P.className "from-hash" ]
         [ P.text cAddress ]
 
-txToView :: Tuple CAddress Coin -> P.Html Action
+txToView :: Tuple CAddress CCoin -> P.Html Action
 txToView (Tuple (CAddress cAddress) _) =
     P.link (toUrl <<< Address $ mkCAddress cAddress)
           [ P.className "to-hash"]
           [ P.text cAddress ]
 
-txBodyAmountView :: Tuple CAddress Coin -> P.Html Action
-txBodyAmountView (Tuple _ (Coin coin)) =
+txBodyAmountView :: Tuple CAddress CCoin -> P.Html Action
+txBodyAmountView (Tuple _ (CCoin coin)) =
     P.div
         [ P.className "amount-wrapper" ]
         [ P.span
             [ P.className "plain-amount bg-ada-dark" ]
-            [ P.text <<< show $ coin ^. getCoin ]
+            [ P.text $ coin ^. getCoin ]
         ]
 
 -- -----------------

--- a/frontend/src/Explorer/View/Dashboard/Transactions.purs
+++ b/frontend/src/Explorer/View/Dashboard/Transactions.purs
@@ -16,7 +16,7 @@ import Explorer.View.Common (currencyCSSClass, noData)
 import Explorer.View.Dashboard.Lenses (dashboardTransactionsExpanded)
 import Explorer.View.Dashboard.Shared (headerView)
 import Explorer.View.Dashboard.Types (HeaderLink(..), HeaderOptions(..))
-import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CTxEntry(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (cteId, cteAmount, cteTimeIssued, _CTxId, _CHash)
 import Pux.Html (Html, div, text) as P
@@ -94,7 +94,7 @@ transactionRow state (CTxEntry entry) =
               [ P.className "transactions__column hash" ]
               [ P.text $ entry ^. (cteId <<< _CTxId <<< _CHash) ]
         , transactionColumn dateValue "date"
-        , transactionColumn (show $ entry ^. (cteAmount <<< _Coin <<< getCoin))
+        , transactionColumn (entry ^. (cteAmount <<< _CCoin <<< getCoin))
               <<< currencyCSSClass $ Just ADA
         ]
 

--- a/frontend/src/Explorer/View/Transaction.purs
+++ b/frontend/src/Explorer/View/Transaction.purs
@@ -12,7 +12,7 @@ import Explorer.Types.Actions (Action)
 import Explorer.Types.State (CCurrency(..), State)
 import Explorer.Util.Time (prettyDate)
 import Explorer.View.Common (currencyCSSClass, emptyTxHeaderView, mkTxBodyViewProps, mkTxHeaderViewProps, noData, txBodyView, txHeaderView)
-import Pos.Core.Lenses.Types (_Coin, getCoin)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CCoin, getCoin)
 import Pos.Explorer.Web.ClientTypes (CTxSummary(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CNetworkAddress, ctsBlockHeight, ctsFees, ctsRelayedBy, ctsTotalOutput, ctsTxTimeIssued)
 import Pux.Html (Html, div, text, h3, p, table, tr, td) as P
@@ -94,11 +94,11 @@ summaryItems (CTxSummary txSummary) lang =
       , currency: Nothing
       }
     , { label: translate (I18nL.common <<< I18nL.cTotalOutput) lang
-      , value: show $ txSummary ^. (ctsTotalOutput <<< _Coin <<< getCoin)
+      , value: txSummary ^. (ctsTotalOutput <<< _CCoin <<< getCoin)
       , currency: Just ADA
       }
     , { label: translate (I18nL.common <<< I18nL.cTransactionFeed) lang
-      , value: show $ txSummary ^. (ctsFees <<< _Coin <<< getCoin)
+      , value: txSummary ^. (ctsFees <<< _CCoin <<< getCoin)
       , currency: Just ADA
       }
     ]

--- a/frontend/src/Explorer/View/Types.purs
+++ b/frontend/src/Explorer/View/Types.purs
@@ -3,20 +3,19 @@ module Exporer.View.Types where
 import Data.Maybe (Maybe)
 import Data.Time.NominalDiffTime (NominalDiffTime)
 import Data.Tuple (Tuple)
-import Pos.Core.Types (Coin)
-import Pos.Explorer.Web.ClientTypes (CAddress, CTxId)
+import Pos.Explorer.Web.ClientTypes (CCoin, CAddress, CTxId)
 
 -- put all view related types here in this file to generate lenses from it
 
 newtype TxHeaderViewProps = TxHeaderViewProps
   { txhHash :: CTxId
   , txhTimeIssued :: Maybe NominalDiffTime
-  , txhAmount :: Coin
+  , txhAmount :: CCoin
   }
 
 
 newtype TxBodyViewProps = TxBodyViewProps
-  { txbInputs :: Array (Tuple CAddress Coin)
-  , txbOutputs :: Array (Tuple CAddress Coin)
-  , txbAmount :: Coin
+  { txbInputs :: Array (Tuple CAddress CCoin)
+  , txbOutputs :: Array (Tuple CAddress CCoin)
+  , txbAmount :: CCoin
   }

--- a/frontend/src/Main.Test.purs
+++ b/frontend/src/Main.Test.purs
@@ -3,7 +3,6 @@ module Main.Test where
 import Prelude
 import Control.Monad.Eff (Eff)
 import Explorer.Routes.Test (testRoutes)
-import Explorer.Util.Factory.Test (testFactoryUtil)
 import Explorer.Util.String.Test (testStringUtil)
 import Explorer.Util.Time.Test (testPrettyDuration)
 import Explorer.View.CSS.Test (testCSS)
@@ -14,6 +13,5 @@ main :: Eff (RunnerEffects ()) Unit
 main = run [consoleReporter] do
     testStringUtil
     testPrettyDuration
-    testFactoryUtil
     testRoutes
     testCSS

--- a/src/Pos/Explorer/Aeson/ClientTypes.hs
+++ b/src/Pos/Explorer/Aeson/ClientTypes.hs
@@ -8,10 +8,10 @@ module Pos.Explorer.Aeson.ClientTypes
 import           Data.Aeson.TH                (defaultOptions, deriveFromJSON, deriveJSON,
                                                deriveToJSON)
 import           Pos.Aeson                    ()
-import           Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary,
-                                               CBlockEntry, CBlockSummary,
-                                               CHash, CNetworkAddress, CTxBrief,
-                                               CTxEntry, CTxId, CTxSummary)
+import           Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary, CBlockEntry,
+                                               CBlockSummary, CCoin, CHash,
+                                               CNetworkAddress, CTxBrief, CTxEntry, CTxId,
+                                               CTxSummary)
 import           Pos.Explorer.Web.Error       (ExplorerError)
 import           Pos.Types                    (ChainDifficulty)
 
@@ -23,6 +23,7 @@ deriveJSON defaultOptions ''CHash
 deriveJSON defaultOptions ''CAddress
 deriveJSON defaultOptions ''CTxId
 
+deriveToJSON defaultOptions ''CCoin
 deriveToJSON defaultOptions ''ExplorerError
 deriveToJSON defaultOptions ''CBlockEntry
 deriveToJSON defaultOptions ''CTxEntry

--- a/src/Pos/Explorer/Socket/App.hs
+++ b/src/Pos/Explorer/Socket/App.hs
@@ -18,8 +18,7 @@ import           Data.Aeson                       (Value)
 import           Data.List                        (intersperse)
 import qualified Data.Set                         as S
 import           Data.Time.Units                  (Millisecond)
-import           Formatting                       (bprint, build, int, sformat, shown,
-                                                   string, (%))
+import           Formatting                       (bprint, build, int, sformat, (%))
 import qualified GHC.Exts                         as Exts
 import           Network.EngineIO                 (SocketId)
 import           Network.EngineIO.Snap            (snapAPI)

--- a/src/Pos/Explorer/Web/Doc.hs
+++ b/src/Pos/Explorer/Web/Doc.hs
@@ -195,6 +195,8 @@ instance ToSample CTxBrief where
             , ctbTimeIssued = posixTime
             , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
             , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
+            , ctbInputSum   = mkCCoin $ mkCoin 33333
+            , ctbOutputSum  = mkCCoin $ mkCoin 33333
             }
 
 instance ToSample CTxSummary where

--- a/src/Pos/Explorer/Web/Doc.hs
+++ b/src/Pos/Explorer/Web/Doc.hs
@@ -16,37 +16,30 @@ import           Control.Lens                   ((<>~))
 import qualified Data.ByteString.Char8          as BSC
 import qualified Data.HashMap.Strict            as HM
 import           Data.String                    as DS
-import           Data.Time                      (defaultTimeLocale,
-                                                 parseTimeOrError)
-import           Data.Time.Clock.POSIX          (POSIXTime,
-                                                 utcTimeToPOSIXSeconds)
+import           Data.Time                      (defaultTimeLocale, parseTimeOrError)
+import           Data.Time.Clock.POSIX          (POSIXTime, utcTimeToPOSIXSeconds)
 import           Pos.Explorer.Aeson.ClientTypes ()
 import           Pos.Explorer.Web.Api           (explorerApi)
-import           Pos.Explorer.Web.ClientTypes   (CAddress (..),
-                                                 CAddressSummary (..),
-                                                 CBlockEntry (..),
-                                                 CBlockSummary (..), CHash (..),
-                                                 CTxBrief (..), CTxEntry (..),
-                                                 CTxId (..), CTxSummary (..),
-                                                 EpochIndex, mkCoin)
+import           Pos.Explorer.Web.ClientTypes   (CAddress (..), CAddressSummary (..),
+                                                 CBlockEntry (..), CBlockSummary (..),
+                                                 CHash (..), CTxBrief (..), CTxEntry (..),
+                                                 CTxId (..), CTxSummary (..), EpochIndex,
+                                                 mkCCoin)
 import           Pos.Explorer.Web.Error         (ExplorerError (..))
+import           Pos.Types                      (mkCoin)
 import           Servant.API                    (Capture, QueryParam)
 import           Servant.Docs                   (API, Action, DocCapture (..),
                                                  DocIntro (..), DocNote (..),
                                                  DocQueryParam (..), Endpoint,
-                                                 ExtraInfo (..),
-                                                 ParamKind (Normal),
-                                                 ToCapture (toCapture),
-                                                 ToParam (toParam),
-                                                 ToSample (toSamples),
-                                                 apiEndpoints, apiIntros,
-                                                 capDesc, capSymbol, captures,
+                                                 ExtraInfo (..), ParamKind (Normal),
+                                                 ToCapture (toCapture), ToParam (toParam),
+                                                 ToSample (toSamples), apiEndpoints,
+                                                 apiIntros, capDesc, capSymbol, captures,
                                                  defAction, defEndpoint,
-                                                 defaultDocOptions, docsWith,
-                                                 introBody, introTitle,
-                                                 markdown, method, noteBody,
-                                                 notes, paramDesc, paramName,
-                                                 params, path, pretty)
+                                                 defaultDocOptions, docsWith, introBody,
+                                                 introTitle, markdown, method, noteBody,
+                                                 notes, paramDesc, paramName, params,
+                                                 path, pretty)
 import           Universum
 
 
@@ -144,7 +137,7 @@ sampleAddressSummary :: CAddressSummary
 sampleAddressSummary = CAddressSummary
     { caAddress = CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv"
     , caTxNum   = 0
-    , caBalance = mkCoin 0
+    , caBalance = mkCCoin $ mkCoin 0
     , caTxList  = []
     }
 --------------------------------------------------------------------------------
@@ -161,7 +154,7 @@ instance ToSample CBlockEntry where
             , cbeBlkHash    = CHash "75aa93bfa1bf8e6aa913bc5fa64479ab4ffc1373a25c8176b61fa1ab9cbae35d"
             , cbeTimeIssued = Nothing
             , cbeTxNum      = 0
-            , cbeTotalSent  = mkCoin 0
+            , cbeTotalSent  = mkCCoin $ mkCoin 0
             , cbeSize       = 390
             , cbeRelayedBy  = Nothing
             }
@@ -176,7 +169,7 @@ instance ToSample CBlockSummary where
                                 , cbeBlkHash    = CHash "75aa93bfa1bf8e6aa913bc5fa64479ab4ffc1373a25c8176b61fa1ab9cbae35d"
                                 , cbeTimeIssued = Nothing
                                 , cbeTxNum      = 0
-                                , cbeTotalSent  = mkCoin 0
+                                , cbeTotalSent  = mkCCoin $ mkCoin 0
                                 , cbeSize       = 390
                                 , cbeRelayedBy  = Nothing
                                 }
@@ -191,7 +184,7 @@ instance ToSample CTxEntry where
         sample = CTxEntry
             { cteId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
             , cteTimeIssued = posixTime
-            , cteAmount     = mkCoin 33333
+            , cteAmount     = mkCCoin $ mkCoin 33333
             }
 
 instance ToSample CTxBrief where
@@ -200,8 +193,8 @@ instance ToSample CTxBrief where
         sample = CTxBrief
             { ctbId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
             , ctbTimeIssued = posixTime
-            , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCoin 33333)]
-            , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCoin 33333)]
+            , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
+            , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
             }
 
 instance ToSample CTxSummary where
@@ -213,11 +206,11 @@ instance ToSample CTxSummary where
             , ctsBlockTimeIssued = Nothing
             , ctsBlockHeight     = Just 11
             , ctsRelayedBy       = Nothing
-            , ctsTotalInput      = mkCoin 33333
-            , ctsTotalOutput     = mkCoin 33333
-            , ctsFees            = mkCoin 0
-            , ctsInputs          = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCoin 33333)]
-            , ctsOutputs         = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCoin 33333)]
+            , ctsTotalInput      = mkCCoin $ mkCoin 33333
+            , ctsTotalOutput     = mkCCoin $ mkCoin 33333
+            , ctsFees            = mkCCoin $ mkCoin 0
+            , ctsInputs          = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
+            , ctsOutputs         = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
             }
 
 instance ToSample CAddressSummary where

--- a/src/Pos/Explorer/Web/TestServer.hs
+++ b/src/Pos/Explorer/Web/TestServer.hs
@@ -123,6 +123,8 @@ testBlocksTxs _ _ _ = pure . pure $ [CTxBrief
     , ctbTimeIssued = posixTime
     , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
     , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
+    , ctbInputSum   = mkCCoin $ mkCoin 33333
+    , ctbOutputSum  = mkCCoin $ mkCoin 33333
     }]
 
 testTxsLast

--- a/src/Pos/Explorer/Web/TestServer.hs
+++ b/src/Pos/Explorer/Web/TestServer.hs
@@ -5,20 +5,16 @@
 
 module Pos.Explorer.Web.TestServer (runMockServer) where
 
-import           Data.Time                      (defaultTimeLocale,
-                                                 parseTimeOrError)
-import           Data.Time.Clock.POSIX          (POSIXTime,
-                                                 utcTimeToPOSIXSeconds)
+import           Data.Time                      (defaultTimeLocale, parseTimeOrError)
+import           Data.Time.Clock.POSIX          (POSIXTime, utcTimeToPOSIXSeconds)
 import           Network.Wai                    (Application)
 import           Network.Wai.Handler.Warp       (run)
 import           Pos.Explorer.Aeson.ClientTypes ()
 import           Pos.Explorer.Web.Api           (ExplorerApi, explorerApi)
-import           Pos.Explorer.Web.ClientTypes   (CAddress (..),
-                                                 CAddressSummary (..),
-                                                 CBlockEntry (..),
-                                                 CBlockSummary (..), CHash (..),
-                                                 CTxBrief (..), CTxEntry (..),
-                                                 CTxId (..), CTxSummary (..))
+import           Pos.Explorer.Web.ClientTypes   (CAddress (..), CAddressSummary (..),
+                                                 CBlockEntry (..), CBlockSummary (..),
+                                                 CHash (..), CTxBrief (..), CTxEntry (..),
+                                                 CTxId (..), CTxSummary (..), mkCCoin)
 import           Pos.Explorer.Web.Error         (ExplorerError (..))
 import           Pos.Types                      (EpochIndex, mkCoin)
 import           Pos.Web                        ()
@@ -76,7 +72,7 @@ sampleAddressSummary :: CAddressSummary
 sampleAddressSummary = CAddressSummary
     { caAddress = CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv"
     , caTxNum   = 0
-    , caBalance = mkCoin 0
+    , caBalance = mkCCoin $ mkCoin 0
     , caTxList  = []
     }
 ----------------------------------------------------------------
@@ -93,7 +89,7 @@ testBlocksLast _ _  = pure . pure $ [CBlockEntry
     , cbeBlkHash    = CHash "75aa93bfa1bf8e6aa913bc5fa64479ab4ffc1373a25c8176b61fa1ab9cbae35d"
     , cbeTimeIssued = Nothing
     , cbeTxNum      = 0
-    , cbeTotalSent  = mkCoin 0
+    , cbeTotalSent  = mkCCoin $ mkCoin 0
     , cbeSize       = 390
     , cbeRelayedBy  = Nothing
     }]
@@ -108,7 +104,7 @@ testBlocksSummary _ = pure . pure $ CBlockSummary
                         , cbeBlkHash    = CHash "75aa93bfa1bf8e6aa913bc5fa64479ab4ffc1373a25c8176b61fa1ab9cbae35d"
                         , cbeTimeIssued = Nothing
                         , cbeTxNum      = 0
-                        , cbeTotalSent  = mkCoin 0
+                        , cbeTotalSent  = mkCCoin $ mkCoin 0
                         , cbeSize       = 390
                         , cbeRelayedBy  = Nothing
                         }
@@ -125,8 +121,8 @@ testBlocksTxs
 testBlocksTxs _ _ _ = pure . pure $ [CTxBrief
     { ctbId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
     , ctbTimeIssued = posixTime
-    , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCoin 33333)]
-    , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCoin 33333)]
+    , ctbInputs     = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
+    , ctbOutputs    = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
     }]
 
 testTxsLast
@@ -136,7 +132,7 @@ testTxsLast
 testTxsLast _ _     = pure . pure $ [CTxEntry
     { cteId         = CTxId $ CHash "b29fa17156275a8589857376bfaeeef47f1846f82ea492a808e5c6155b450e02"
     , cteTimeIssued = posixTime
-    , cteAmount     = mkCoin 33333
+    , cteAmount     = mkCCoin $ mkCoin 33333
     }]
 
 testTxsSummary
@@ -148,11 +144,11 @@ testTxsSummary _       = pure . pure $ CTxSummary
     , ctsBlockTimeIssued = Nothing
     , ctsBlockHeight     = Just 11
     , ctsRelayedBy       = Nothing
-    , ctsTotalInput      = mkCoin 33333
-    , ctsTotalOutput     = mkCoin 33333
-    , ctsFees            = mkCoin 0
-    , ctsInputs          = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCoin 33333)]
-    , ctsOutputs         = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCoin 33333)]
+    , ctsTotalInput      = mkCCoin $ mkCoin 33333
+    , ctsTotalOutput     = mkCCoin $ mkCoin 33333
+    , ctsFees            = mkCCoin $ mkCoin 0
+    , ctsInputs          = [(CAddress "1fi9sA3pRt8bKVibdun57iyWG9VsWZscgQigSik6RHoF5Mv", mkCCoin $ mkCoin 33333)]
+    , ctsOutputs         = [(CAddress "1fSCHaQhy6L7Rfjn9xR2Y5H7ZKkzKLMXKYLyZvwWVffQwkQ", mkCCoin $ mkCoin 33333)]
     }
 
 testAddressSummary
@@ -170,7 +166,7 @@ testEpochSlotSearch _ _ = pure . pure $ [CBlockEntry
     , cbeBlkHash    = CHash "75aa93bfa1bf8e6aa913bc5fa64479ab4ffc1373a25c8176b61fa1ab9cbae35d"
     , cbeTimeIssued = Nothing
     , cbeTxNum      = 0
-    , cbeTotalSent  = mkCoin 0
+    , cbeTotalSent  = mkCCoin $ mkCoin 0
     , cbeSize       = 390
     , cbeRelayedBy  = Nothing
     }]

--- a/src/purescript/Main.hs
+++ b/src/purescript/Main.hs
@@ -33,7 +33,7 @@ main = do
       , mkSumType (Proxy @CT.CTxId)
       , mkSumType (Proxy @CT.CTxSummary)
       , mkSumType (Proxy @CE.ExplorerError)
-      , mkSumType (Proxy @CT.Coin)
+      , mkSumType (Proxy @CT.CCoin)
       , mkSumType (Proxy @PS.ClientEvent)
       , mkSumType (Proxy @PS.ServerEvent)
       , mkSumType (Proxy @PS.Subscription)

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -3,7 +3,7 @@
 # Optional path for `cardano-sl`
 cardano_path=${1:-../cardano-sl}
 
-./scripts/run.sh ../cardano-sl/scripts/common.sh & PIDEX=$!
+./scripts/run.sh $cardano_path/scripts/common.sh & PIDEX=$!
 $cardano_path/util-scripts/start-prod.sh & PIDNODE=$!
 wait $PIDEX
 wait $PIDNODE


### PR DESCRIPTION
Backend is using `CCoin` instead of `Coin` in types now. So frontend has to be refactored to reflect this change. Refactor is straightforward. Frontend build should fail as there is not `Coin` type bridged now. Use `CCoin` instead.

@ksaric @sectore can you refactor the frontend to reflect this change?