### PR TITLE
[CSM-226] Endpoint that returns number of blocks

### DIFF
--- a/src/Pos/Explorer/Web/Api.hs
+++ b/src/Pos/Explorer/Web/Api.hs
@@ -45,6 +45,11 @@ type ExplorerApi =
       :> Get '[JSON] (Either ExplorerError [CTxBrief])
     :<|>
       "api"
+      :> "blocks"
+      :> "total"
+      :> Get '[JSON] (Either ExplorerError Int)
+    :<|>
+      "api"
       :> "txs"
       :> "last"
       :> QueryParam "limit" Word

--- a/src/Pos/Explorer/Web/Doc.hs
+++ b/src/Pos/Explorer/Web/Doc.hs
@@ -159,6 +159,9 @@ instance ToSample CBlockEntry where
             , cbeRelayedBy  = Nothing
             }
 
+instance ToSample Int where
+    toSamples Proxy = [("Sample Int", 1)]
+
 instance ToSample CBlockSummary where
     toSamples Proxy = [("Sample block summary", sample)]
       where

--- a/src/Pos/Explorer/Web/Server.hs
+++ b/src/Pos/Explorer/Web/Server.hs
@@ -28,41 +28,54 @@ import           Universum
 import           Pos.Communication              (SendActions)
 import           Pos.Crypto                     (WithHash (..), hash, withHash)
 import qualified Pos.DB.Block                   as DB
+import qualified Pos.DB.DB                      as DB
 import qualified Pos.DB.GState                  as GS
 import qualified Pos.DB.GState.Balances         as GS
 
 import           Pos.Slotting                   (MonadSlots (..), getSlotStart)
 import           Pos.Ssc.Class                  (SscHelpersClass)
 import           Pos.Ssc.GodTossing             (SscGodTossing)
-import           Pos.Txp                        (Tx (..), TxAux, TxId, TxOutAux (..),
-                                                 getLocalTxs, getMemPool, mpLocalTxs,
-                                                 topsortTxs, txOutValue, _txOutputs)
-import           Pos.Types                      (Address (..), Block, EpochIndex,
-                                                 HeaderHash, LocalSlotIndex (..),
-                                                 MainBlock, Timestamp, blockSlot,
-                                                 blockTxs, difficultyL, gbHeader,
-                                                 gbhConsensus, genesisHash, mcdSlot,
-                                                 mkCoin, prevBlockL, siEpoch, siSlot,
-                                                 sumCoins, unsafeIntegerToCoin,
+import           Pos.Txp                        (Tx (..), TxAux, TxId,
+                                                 TxOutAux (..), getLocalTxs,
+                                                 getMemPool, mpLocalTxs,
+                                                 topsortTxs, txOutValue,
+                                                 _txOutputs)
+import           Pos.Types                      (Address (..), Block,
+                                                 EpochIndex, HeaderHash,
+                                                 LocalSlotIndex (..), MainBlock,
+                                                 Timestamp, blockSlot, blockTxs,
+                                                 difficultyL, gbHeader,
+                                                 gbhConsensus, genesisHash,
+                                                 getChainDifficulty, mcdSlot,
+                                                 mkCoin, prevBlockL, siEpoch,
+                                                 siSlot, sumCoins,
+                                                 unsafeIntegerToCoin,
                                                  unsafeSubCoin)
 import           Pos.Util                       (maybeThrow)
 import           Pos.Util.Chrono                (NewestFirst (..))
 import           Pos.Web                        (serveImpl)
 import           Pos.WorkMode                   (WorkMode)
+import           Pos.DB.Class                   (MonadDB)
 
 import           Pos.Explorer                   (TxExtra (..), getTxExtra)
-import qualified Pos.Explorer                   as EX (getAddrHistory, getTxExtra)
+import qualified Pos.Explorer                   as EX (getAddrHistory,
+                                                       getTxExtra)
 import           Pos.Explorer.Aeson.ClientTypes ()
 import           Pos.Explorer.Web.Api           (ExplorerApi, explorerApi)
-import           Pos.Explorer.Web.ClientTypes   (CAddress (..), CAddressSummary (..),
-                                                 CBlockEntry (..), CBlockSummary (..),
-                                                 CHash, CTxBrief (..), CTxEntry (..),
+import           Pos.Explorer.Web.ClientTypes   (CAddress (..),
+                                                 CAddressSummary (..),
+                                                 CBlockEntry (..),
+                                                 CBlockSummary (..), CHash,
+                                                 CTxBrief (..), CTxEntry (..),
                                                  CTxId (..), CTxSummary (..),
-                                                 TxInternal (..), convertTxOutputs,
-                                                 fromCAddress, fromCHash, fromCTxId,
-                                                 mkCCoin, tiToTxEntry, toBlockEntry,
-                                                 toBlockSummary, toPosixTime, toTxBrief)
+                                                 TxInternal (..),
+                                                 convertTxOutputs, fromCAddress,
+                                                 fromCHash, fromCTxId, mkCCoin,
+                                                 tiToTxEntry, toBlockEntry,
+                                                 toBlockSummary, toPosixTime,
+                                                 toTxBrief)
 import           Pos.Explorer.Web.Error         (ExplorerError (..))
+
 
 
 
@@ -93,6 +106,8 @@ explorerHandlers _sendActions =
     :<|>
       apiBlocksTxs
     :<|>
+      apiBlocksTotalNumber
+    :<|>
       apiTxsLast
     :<|>
       apiTxsSummary
@@ -104,6 +119,7 @@ explorerHandlers _sendActions =
     apiBlocksLast       = getLastBlocksDefault
     apiBlocksSummary    = catchExplorerError . getBlockSummary
     apiBlocksTxs        = getBlockTxsDefault
+    apiBlocksTotalNumber= catchExplorerError $ getBlocksTotalNumber
     apiTxsLast          = getLastTxsDefault
     apiTxsSummary       = catchExplorerError . getTxSummary
     apiAddressSummary   = catchExplorerError . getAddressSummary
@@ -125,6 +141,24 @@ explorerHandlers _sendActions =
 
     defaultLimit limit = (fromIntegral $ fromMaybe 100 limit)
     defaultSkip  skip  = (fromIntegral $ fromMaybe 0 skip)
+
+-- | Get the total number of blocks/slots currently available.
+-- Total number of main blocks   = difficulty of the topmost (tip) header.
+-- Total number of anchor blocks = current epoch + 1
+getBlocksTotalNumber
+    :: (MonadDB m)
+    => m Int
+getBlocksTotalNumber = do
+    -- Get the tip block.
+    tipBlock <- DB.getTipBlock @SscGodTossing
+    -- -1 is for the genesis block I guess?
+    pure $ checkMaxBlocks $ maxBlocks tipBlock - 1
+  where
+    maxBlocks tipBlock = fromIntegral $ getChainDifficulty $ tipBlock ^. difficultyL
+    -- This just makes sure that the values aren't negative at the start.
+    checkMaxBlocks x
+      | x >= 0    = x
+      | otherwise = 0
 
 -- | Search the blocks by epoch and slot. Slot is optional.
 epochSlotSearch

--- a/src/Pos/Explorer/Web/TestServer.hs
+++ b/src/Pos/Explorer/Web/TestServer.hs
@@ -46,6 +46,8 @@ explorerHandlers =
     :<|>
       apiBlocksTxs
     :<|>
+      apiBlocksTotalNumber
+    :<|>
       apiTxsLast
     :<|>
       apiTxsSummary
@@ -57,6 +59,7 @@ explorerHandlers =
     apiBlocksLast       = testBlocksLast
     apiBlocksSummary    = testBlocksSummary
     apiBlocksTxs        = testBlocksTxs
+    apiBlocksTotalNumber= testBlocksTotalNumber
     apiTxsLast          = testTxsLast
     apiTxsSummary       = testTxsSummary
     apiAddressSummary   = testAddressSummary
@@ -126,6 +129,10 @@ testBlocksTxs _ _ _ = pure . pure $ [CTxBrief
     , ctbInputSum   = mkCCoin $ mkCoin 33333
     , ctbOutputSum  = mkCCoin $ mkCoin 33333
     }]
+
+testBlocksTotalNumber
+    :: Handler (Either ExplorerError Int)
+testBlocksTotalNumber = pure . pure $ 333
 
 testTxsLast
     :: Maybe Word


### PR DESCRIPTION
Tested on `dev` mode with(you can remove `jq` if you aren't using it, it's a useful tool):
`curl http://localhost:8100/api/blocks/last | jq . `
```
{
  "Right": [
    {
      "cbeEpoch": 0,
      "cbeSlot": 3,
      "cbeBlkHash": "41677fdf223130f91fadfb2f2304649278af08442e1d00e956931a8efc1fa513",
      "cbeTimeIssued": 1493732828,
      "cbeTxNum": 0,
      "cbeTotalSent": {
        "getCoin": "0"
      },
      "cbeSize": 423,
      "cbeRelayedBy": null
    },
    {
      "cbeEpoch": 0,
      "cbeSlot": 2,
      "cbeBlkHash": "6f2733df8734125c0cf7bb7996f097aabc392aee32c02f93ad827b4e2cb9c112",
      "cbeTimeIssued": 1493732821,
      "cbeTxNum": 0,
      "cbeTotalSent": {
        "getCoin": "0"
      },
      "cbeSize": 585,
      "cbeRelayedBy": null
    },
    {
      "cbeEpoch": 0,
      "cbeSlot": 1,
      "cbeBlkHash": "b31ad06102b38d83b084b8e3d597b89e719908026bb6efc01979fdeabdb53569",
      "cbeTimeIssued": 1493732814,
      "cbeTxNum": 0,
      "cbeTotalSent": {
        "getCoin": "0"
      },
      "cbeSize": 1565,
      "cbeRelayedBy": null
    },
    {
      "cbeEpoch": 0,
      "cbeSlot": 0,
      "cbeBlkHash": "ce541bd5d17f509500df6b84f22ab0a3d76e07701b03cf8f6e9bdeba6a0c6300",
      "cbeTimeIssued": 1493732807,
      "cbeTxNum": 0,
      "cbeTotalSent": {
        "getCoin": "0"
      },
      "cbeSize": 423,
      "cbeRelayedBy": null
    }
  ]
}
```
`curl http://localhost:8100/api/blocks/total | jq .`
```
{
  "Right": 4
}
```
