### PR TITLE
CSM-243 Change socket.io logging name

### DIFF
--- a/src/Pos/Explorer/Socket/App.hs
+++ b/src/Pos/Explorer/Socket/App.hs
@@ -71,7 +71,7 @@ toSnapConfig NotifierSettings{..} loggerName = Config.defaultConfig
   where
     logHandler severity =
         Just . Config.ConfigIoLog $
-            usingLoggerName (loggerName <> "socket-io") .
+            usingLoggerName (loggerName <> "requests") .
             logMessage severity . decodeUtf8
 
 notifierHandler
@@ -175,7 +175,7 @@ notifierApp
     :: forall ssc m.
        (ExplorerMode m, SscHelpersClass ssc)
     => NotifierSettings -> m ()
-notifierApp settings = modifyLoggerName (<> "notifier") $ do
+notifierApp settings = modifyLoggerName (<> "notifier.socket-io") $ do
     logInfo "Starting"
     connVar <- liftIO $ STM.newTVarIO mkConnectionsState
     forkAccompanion (periodicPollChanges @ssc connVar)


### PR DESCRIPTION
https://issues.serokell.io/issue/CSM-243

Before the loggers were names:
* node.plugin.notifier.socket-io
* node.plugin.notifier

node.plugin.notifier.socket-io was for requests.
node.plugin.notifier was for socket.io.

Switching the logger name to the correct name node.plugin.notifier.socket-io.
Also, requests now get called on node.plugin.notifier.socket-io.requests.

Now we can take a look at the file socket-io.log and see everything relating to socket.io.
