### PR TITLE
[DEVOPS-129] Remove NIX_PATH from build script as it's redundant

### DIFF
--- a/frontend/scripts/build.sh
+++ b/frontend/scripts/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -j 4 -i bash -p stack git
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/763e21e982370f67c126f92a1113ea949db3b6e0.tar.gz
-export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/763e21e982370f67c126f92a1113ea949db3b6e0.tar.gz
 
 set -xe
 


### PR DESCRIPTION
There is no need to set `NIX_PATH` as it's already specified in `shell.nix`.

On the other hand this doesn't allow setting it when avoiding stack.