### PR TITLE
[CSE-116] Extend transaction list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ node-db/*
 *.log
 wallet-db/*
 logs/*
+explorer.log.*
 explorer-node.log.*
+socket-io.log.*
 
 # Intellij Idea & intellij-haskell
 .idea

--- a/frontend/src/Explorer/View/Address.purs
+++ b/frontend/src/Explorer/View/Address.purs
@@ -1,21 +1,21 @@
 module Explorer.View.Address where
 
 import Prelude
-import Data.Array (length, (!!))
+import Data.Array (length, null, slice)
 import Data.Lens ((^.))
 import Data.Maybe (Maybe(..), isJust)
 import Explorer.I18n.Lang (Language, translate)
-import Explorer.I18n.Lenses (addNotFound, cAddress, cBack2Dashboard, common, cLoading, cOf, cTransactions, address, addScan, addQrCode, addFinalBalance, tx, txEmpty) as I18nL
+import Explorer.I18n.Lenses (addNotFound, cAddress, cBack2Dashboard, common, cLoading, cOf, cTransactions, address, addScan, addQrCode, addFinalBalance, tx, txEmpty, txNotFound) as I18nL
 import Explorer.Lenses.State (_PageNumber, addressDetail, addressTxPagination, addressTxPaginationEditable, currentAddressSummary, lang, viewStates)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (addressQRImageId, minPagination)
 import Explorer.Types.Actions (Action(..))
-import Explorer.Types.State (CCurrency(..), PageNumber(..), State)
+import Explorer.Types.State (CCurrency(..), PageNumber(..), State, CTxBriefs)
 import Explorer.Util.String (formatADA)
-import Explorer.View.Common (currencyCSSClass, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
+import Explorer.View.Common (currencyCSSClass, getMaxPaginationNumber, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
 import Network.RemoteData (RemoteData(..))
-import Pos.Explorer.Web.ClientTypes (CAddressSummary(..))
-import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxList, caTxNum)
+import Pos.Explorer.Web.ClientTypes (CAddressSummary(..), CTxBrief)
+import Pos.Explorer.Web.Lenses.ClientTypes (_CAddress, caAddress, caBalance, caTxNum)
 import Pux.Html (Html, div, text, span, h3, p) as P
 import Pux.Html.Attributes (className, dangerouslySetInnerHTML, id_) as P
 import Pux.Router (link) as P
@@ -41,39 +41,13 @@ addressView state =
                 [ P.div
                       [ P.className "explorer-address__container" ]
                       [ case state ^. currentAddressSummary of
-                            NotAsked  -> emptyAddressTxView
-                            Loading   -> emptyAddressTxView
-                            Failure _ -> emptyAddressTxView
+                            NotAsked  -> txEmptyContentView ""
+                            Loading   -> txEmptyContentView $
+                                translate (I18nL.common <<< I18nL.cLoading) lang'
+                            Failure _ -> txEmptyContentView $
+                                translate (I18nL.tx <<< I18nL.txNotFound) lang'
                             Success (CAddressSummary addressSummary) ->
-                                let txList = addressSummary ^. caTxList
-                                    txPagination = state ^. (viewStates <<< addressDetail <<< addressTxPagination <<< _PageNumber)
-                                    currentTxBrief = txList !! (txPagination - 1)
-                                in
-                                P.div
-                                    []
-                                    [ P.h3
-                                          [ P.className "headline"]
-                                          [ P.text $ translate (I18nL.common <<< I18nL.cTransactions) lang' ]
-                                    , case currentTxBrief of
-                                        Nothing ->
-                                            txEmptyContentView $ translate (I18nL.tx <<< I18nL.txEmpty) lang'
-                                        Just txBrief ->
-                                            P.div []
-                                            [ txHeaderView lang' $ mkTxHeaderViewProps txBrief
-                                            , txBodyView lang' $ mkTxBodyViewProps txBrief
-                                            , txPaginationView
-                                                  { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
-                                                  , currentPage: PageNumber txPagination
-                                                  , minPage: PageNumber minPagination
-                                                  , maxPage: PageNumber $ length txList
-                                                  , changePageAction: AddressPaginateTxs
-                                                  , editable: state ^. (viewStates <<< addressDetail <<< addressTxPaginationEditable)
-                                                  , editableAction: AddressEditTxsPageNumber
-                                                  , invalidPageAction: AddressInvalidTxsPageNumber
-                                                  , disabled: false
-                                                  }
-                                            ]
-                                    ]
+                                addressTxsView addressSummary.caTxList state
                 ]
             ]
         ]
@@ -168,11 +142,73 @@ emptyAddressDetail message =
             []
         ]
 
-emptyAddressTxView :: P.Html Action
-emptyAddressTxView =
+maxTxRows :: Int
+maxTxRows = 5
+
+addressTxsView :: CTxBriefs -> State -> P.Html Action
+addressTxsView txs state =
+    if null txs then
+        txEmptyContentView $ translate (I18nL.tx <<< I18nL.txEmpty) (state ^. lang)
+    else
+    let txPagination = state ^. (viewStates <<< addressDetail <<< addressTxPagination <<< _PageNumber)
+        lang' = state ^. lang
+        minTxIndex = (txPagination - minPagination) * maxTxRows
+        currentTxs = slice minTxIndex (minTxIndex + maxTxRows) txs
+    in
     P.div
-        [ P.className "explorer-address__container" ]
         []
+        [ P.div
+              []
+              $ map (\tx -> addressTxView tx lang') currentTxs
+        , txPaginationView  { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
+                            , currentPage: PageNumber txPagination
+                            , minPage: PageNumber minPagination
+                            , maxPage: PageNumber $ getMaxPaginationNumber (length txs) maxTxRows
+                            , changePageAction: AddressPaginateTxs
+                            , editable: state ^. (viewStates <<< addressDetail <<< addressTxPaginationEditable)
+                            , editableAction: AddressEditTxsPageNumber
+                            , invalidPageAction: AddressInvalidTxsPageNumber
+                            , disabled: false
+                            }
+        ]
+
+addressTxView :: CTxBrief -> Language -> P.Html Action
+addressTxView tx lang =
+    P.div
+        []
+        [ txHeaderView lang $ mkTxHeaderViewProps tx
+        , txBodyView lang $ mkTxBodyViewProps tx
+        ]
+
+-- let txList = addressSummary ^. caTxList
+--     txPagination = state ^. (viewStates <<< addressDetail <<< addressTxPagination <<< _PageNumber)
+--     currentTxBrief = txList !! (txPagination - 1)
+-- in
+-- P.div
+--     []
+--     [ P.h3
+--           [ P.className "headline"]
+--           [ P.text $ translate (I18nL.common <<< I18nL.cTransactions) lang' ]
+--     , case currentTxBrief of
+--         Nothing ->
+--             txEmptyContentView $ translate (I18nL.tx <<< I18nL.txEmpty) lang'
+--         Just txBrief ->
+--             P.div []
+--             [ txHeaderView lang' $ mkTxHeaderViewProps txBrief
+--             , txBodyView lang' $ mkTxBodyViewProps txBrief
+--             , txPaginationView
+--                   { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
+--                   , currentPage: PageNumber txPagination
+--                   , minPage: PageNumber minPagination
+--                   , maxPage: PageNumber $ length txList
+--                   , changePageAction: AddressPaginateTxs
+--                   , editable: state ^. (viewStates <<< addressDetail <<< addressTxPaginationEditable)
+--                   , editableAction: AddressEditTxsPageNumber
+--                   , invalidPageAction: AddressInvalidTxsPageNumber
+--                   , disabled: false
+--                   }
+--             ]
+--     ]
 
 failureView :: Language -> P.Html Action
 failureView lang =

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -1,7 +1,7 @@
 module Explorer.View.Block (blockView) where
 
 import Prelude
-import Data.Array (length, null, slice, (..))
+import Data.Array (length, null, slice)
 import Data.Lens ((^.))
 import Data.Maybe (Maybe(..), isJust)
 import Explorer.I18n.Lang (Language, translate)
@@ -9,7 +9,6 @@ import Explorer.I18n.Lenses (cBlock, blSlotNotFound, common, cBack2Dashboard, cO
 import Explorer.Lenses.State (_PageNumber, blockDetail, blockTxPagination, blockTxPaginationEditable, currentBlockSummary, currentBlockTxs, lang, viewStates)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (minPagination)
-import Explorer.Test.MockFactory (mkTxBriefs)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), CTxBriefs, PageNumber(..), State)
 import Explorer.Util.Factory (mkCoin)
@@ -58,9 +57,7 @@ blockView state =
                       NotAsked -> txEmptyContentView ""
                       Loading -> txEmptyContentView $ translate (I18nL.common <<< I18nL.cLoading) lang'
                       Failure _ -> txEmptyContentView $ translate (I18nL.tx <<< I18nL.txNotFound) lang'
-                      -- Success txs -> blockTxsView txs state
-                      -- TODO (jk): Use real data
-                      Success txs -> blockTxsView (mkTxBriefs (1..12)) state
+                      Success txs -> blockTxsView txs state
                 ]
             , if (isFailure blockSummary && isFailure blockTxs)
               -- Show back button if both results ^ are failed

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -1,21 +1,22 @@
 module Explorer.View.Block (blockView) where
 
 import Prelude
-import Data.Array (length, null, (!!))
+import Data.Array (length, null, slice, (..))
 import Data.Lens ((^.))
-import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Maybe (Maybe(..), isJust)
 import Explorer.I18n.Lang (Language, translate)
 import Explorer.I18n.Lenses (cBlock, blSlotNotFound, common, cBack2Dashboard, cOf, cLoading, cNotAvailable, block, blFees, blRoot, blNextBlock, blPrevBlock, blEstVolume, cHash, cSummary, cTotalOutput, cHashes, cSlot, cTransactions, tx, txNotFound, txEmpty) as I18nL
 import Explorer.Lenses.State (_PageNumber, blockDetail, blockTxPagination, blockTxPaginationEditable, currentBlockSummary, currentBlockTxs, lang, viewStates)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (minPagination)
+import Explorer.Test.MockFactory (mkTxBriefs)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), CTxBriefs, PageNumber(..), State)
 import Explorer.Util.Factory (mkCoin)
 import Explorer.Util.String (formatADA)
-import Explorer.View.Common (currencyCSSClass, emptyView, mkEmptyViewProps, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
+import Explorer.View.Common (currencyCSSClass, emptyView, getMaxPaginationNumber, mkTxBodyViewProps, mkTxHeaderViewProps, txBodyView, txEmptyContentView, txHeaderView, txPaginationView)
 import Network.RemoteData (RemoteData(..), isFailure)
-import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..))
+import Pos.Explorer.Web.ClientTypes (CBlockEntry(..), CBlockSummary(..), CTxBrief)
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CBlockSummary, _CHash, cbeBlkHash, cbeSlot, cbeTotalSent, cbeTxNum, cbsEntry, cbsMerkleRoot, cbsNextHash, cbsPrevHash)
 import Pux.Html (Html, div, text, h3, span) as P
 import Pux.Html.Attributes (className) as P
@@ -57,7 +58,9 @@ blockView state =
                       NotAsked -> txEmptyContentView ""
                       Loading -> txEmptyContentView $ translate (I18nL.common <<< I18nL.cLoading) lang'
                       Failure _ -> txEmptyContentView $ translate (I18nL.tx <<< I18nL.txNotFound) lang'
-                      Success txs -> blockTxsView txs state
+                      -- Success txs -> blockTxsView txs state
+                      -- TODO (jk): Use real data
+                      Success txs -> blockTxsView (mkTxBriefs (1..12)) state
                 ]
             , if (isFailure blockSummary && isFailure blockTxs)
               -- Show back button if both results ^ are failed
@@ -210,26 +213,28 @@ hashesRow item =
                               [ P.text item.hash ]
         ]
 
+maxTxRows :: Int
+maxTxRows = 5
+
 blockTxsView :: CTxBriefs -> State -> P.Html Action
 blockTxsView txs state =
     if null txs then
         txEmptyContentView $ translate (I18nL.tx <<< I18nL.txEmpty) (state ^. lang)
     else
         let txPagination = state ^. (viewStates <<< blockDetail <<< blockTxPagination <<< _PageNumber)
-            currentTxBrief = txs !! (txPagination - 1)
-            txBodyViewProps = fromMaybe (mkTxBodyViewProps mkEmptyViewProps) $ mkTxBodyViewProps <$> currentTxBrief
             lang' = state ^. lang
+            minTxIndex = (txPagination - minPagination) * maxTxRows
+            currentTxs = slice minTxIndex (minTxIndex + maxTxRows) txs
         in
         P.div
             []
-            [ txHeaderView lang' $ case currentTxBrief of
-                                        Nothing -> mkTxHeaderViewProps mkEmptyViewProps
-                                        Just txBrief -> mkTxHeaderViewProps txBrief
-            , txBodyView lang' txBodyViewProps
+            [ P.div
+                  []
+                  $ map (\tx -> blockTxView tx lang') currentTxs
             , txPaginationView  { label: translate (I18nL.common <<< I18nL.cOf) $ lang'
                                 , currentPage: PageNumber txPagination
                                 , minPage: PageNumber minPagination
-                                , maxPage: PageNumber $ length txs
+                                , maxPage: PageNumber $ getMaxPaginationNumber (length txs) maxTxRows
                                 , changePageAction: BlockPaginateTxs
                                 , editable: state ^. (viewStates <<< blockDetail <<< blockTxPaginationEditable)
                                 , editableAction: BlockEditTxsPageNumber
@@ -237,3 +242,11 @@ blockTxsView txs state =
                                 , disabled: false
                                 }
             ]
+
+blockTxView :: CTxBrief -> Language -> P.Html Action
+blockTxView tx lang =
+    P.div
+        []
+        [ txHeaderView lang $ mkTxHeaderViewProps tx
+        , txBodyView lang $ mkTxBodyViewProps tx
+        ]

--- a/frontend/src/Test/MockFactory.purs
+++ b/frontend/src/Test/MockFactory.purs
@@ -5,11 +5,14 @@
 module Explorer.Test.MockFactory where
 
 import Prelude
+import Data.Array ((..))
 import Data.Lens (set)
 import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
 import Data.Time.NominalDiffTime (NominalDiffTime, mkTime)
 import Explorer.Util.Factory (mkCAddress, mkCHash, mkCTxId, mkCoin)
-import Pos.Explorer.Web.ClientTypes (CAddressSummary(..), CAddressType(..), CBlockEntry(..), CHash, CTxEntry(..), CTxId)
+import Explorer.Types.State (CTxBriefs)
+import Pos.Explorer.Web.ClientTypes (CAddress, CAddressSummary(..), CAddressType(..), CBlockEntry(..), CCoin, CHash, CTxEntry(..), CTxId, CTxBrief(..))
 import Pos.Explorer.Web.Lenses.ClientTypes (_CBlockEntry, _CTxEntry, cbeBlkHash, cbeEpoch, cbeSlot, cbeTimeIssued, cteId, cteTimeIssued)
 
 -- | Creates a `CTxEntry` with "empty" data
@@ -67,3 +70,25 @@ setEpochSlotOfBlock epoch slot block =
 setHashOfBlock :: CHash -> CBlockEntry -> CBlockEntry
 setHashOfBlock hash block =
     set (_CBlockEntry <<< cbeBlkHash) hash block
+
+mkTxBriefs :: Array Int -> CTxBriefs
+mkTxBriefs indexes =
+    map mkCTxBrief indexes
+
+mkCTxBrief :: Int -> CTxBrief
+mkCTxBrief index = CTxBrief
+    { ctbId: mkCTxId $ show index
+    , ctbTimeIssued: mkTime 0.0
+    , ctbInputs: mkCtbInOutputs [index]
+    , ctbOutputs: mkCtbInOutputs ((index + 1)..(index + 2))
+    , ctbInputSum: mkCoin "0"
+    , ctbOutputSum: mkCoin "0"
+    }
+
+mkCtbInOutput :: Int -> Int -> Tuple CAddress CCoin
+mkCtbInOutput addr coin =
+    Tuple (mkCAddress $ "address-" <> show addr) (mkCoin $ show coin)
+
+mkCtbInOutputs :: Array Int -> Array (Tuple CAddress CCoin)
+mkCtbInOutputs indexes =
+    map (\index -> mkCtbInOutput index index) indexes


### PR DESCRIPTION
to have up to `5` transactions at `Slot` and `Address` detail pages. 

_Screen shot of `Slot` detail page_ (currently 3 transactions):

![slot-detail-page](https://user-images.githubusercontent.com/47693/27175719-62ded4f8-51c0-11e7-96e6-49dbbbd2eb93.png)

_Screen shot of `Address` detail page_ (currently 7 transactions, 5 txs at page `1`):

![address-detail-page](https://user-images.githubusercontent.com/47693/27175752-7c03e2c0-51c0-11e7-873a-839afe6d9642.png)