### PR TITLE
[CSE-146] Fix socket subscription leak

### DIFF
--- a/src/Pos/Explorer/Socket/Methods.hs
+++ b/src/Pos/Explorer/Socket/Methods.hs
@@ -306,6 +306,7 @@ unsubscribeFully sessId = do
     modifyLoggerName (const "drop") $ do
         unsubscribeAddr sessId
         unsubscribeBlocks sessId
+        unsubscribeBlocksLastPage sessId
         unsubscribeBlocksOff sessId
         unsubscribeTxs sessId
 


### PR DESCRIPTION
It seems there was a missing un-subscription of `BlocksLastPage`, which causes the leak.

With this fix error messages about `No socket with SocketId="XYZ" registered` are gone:

```
...
[92m[node.plugin.notifier.socket-io.requests:DEBUG:ThreadId 4388] [0m[2017-07-03 13:27:12 CEST] 127.0.0.1 - - [03/Jul/2017:13:27:12 +0200] "GET /socket.io/?EIO=3&transport=polling&t=Lq8D51i&sid=JyweGy8xPRc%2BJR46DyEd HTTP/1.1" 200 18 "http://localhost:3100/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" unsubscribed from txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" unsubscribed from blockchain last page updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" unsubscribed from txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" subscribed to txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" unsubscribed from blockchain last page updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4389] [0m[2017-07-03 13:27:13 CEST] Client #"JyweGy8xPRc+JR46DyEd" subscribed to blockchain last page updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 59] [0m[2017-07-03 13:27:28 CEST] Blockchain updated (1 blocks)
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 59] [0m[2017-07-03 13:27:48 CEST] Blockchain updated (1 blocks)
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 59] [0m[2017-07-03 13:27:53 CEST] Blockchain updated (1 blocks)
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 59] [0m[2017-07-03 13:28:03 CEST] Blockchain updated (1 blocks)
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4392] [0m[2017-07-03 13:28:14 CEST] Client #"JyweGy8xPRc+JR46DyEd" unsubscribes from all updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 4392] [0m[2017-07-03 13:28:14 CEST] Session #"JyweGy8xPRc+JR46DyEd" has finished
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5321] [0m[2017-07-03 13:28:16 CEST] New session has started (#"GRkcDAUzAyk2Gh8zAy04")
[92m[node.plugin.notifier.socket-io.requests:DEBUG:ThreadId 5321] [0m[2017-07-03 13:28:16 CEST] 127.0.0.1 - - [03/Jul/2017:13:28:16 +0200] "GET /socket.io/?EIO=3&transport=polling&t=Lq8DKfm HTTP/1.1" 200 114 "http://localhost:3100/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
[92m[node.plugin.notifier.socket-io.requests:DEBUG:ThreadId 5321] [0m[2017-07-03 13:28:16 CEST] 127.0.0.1 - - [03/Jul/2017:13:28:16 +0200] "GET /socket.io/?EIO=3&transport=polling&t=Lq8DKfu&sid=GRkcDAUzAyk2Gh8zAy04 HTTP/1.1" 200 18 "http://localhost:3100/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" unsubscribed from txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" unsubscribed from blockchain last page updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" unsubscribed from txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" subscribed to txs updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" unsubscribed from blockchain last page updates
[92m[node.plugin.notifier.socket-io:DEBUG:ThreadId 5322] [0m[2017-07-03 13:28:17 CEST] Client #"GRkcDAUzAyk2Gh8zAy04" subscribed to blockchain last page updates
 ...
```