### PR TITLE
[CSE-180] Add `test-net` info icon

### DIFF
--- a/frontend/src/Explorer/State.purs
+++ b/frontend/src/Explorer/State.purs
@@ -69,6 +69,7 @@ initialState =
     , errors: []
     , loading: false
     , now: toDateTime $ unsafePartial $ fromJust $ instant $ Milliseconds 0.0
+    , testnet: false
     }
 
 -- all constants are following here:

--- a/frontend/src/Explorer/Types/State.purs
+++ b/frontend/src/Explorer/Types/State.purs
@@ -35,6 +35,7 @@ type State =
     , errors :: Errors
     , loading :: Boolean
     , now :: DateTime
+    , testnet :: Boolean
     }
 
 data Search

--- a/frontend/src/Explorer/Util/Config.Test.purs
+++ b/frontend/src/Explorer/Util/Config.Test.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Aff (Aff)
 import Control.Monad.State (StateT)
 import Data.Identity (Identity)
-import Explorer.Util.Config (SyncAction(..), syncByPolling, syncBySocket)
+import Explorer.Util.Config (SyncAction(..), isTestnet, syncByPolling, syncBySocket)
 import Test.Spec (Group, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
@@ -22,3 +22,8 @@ testConfigUtil =
                 (syncByPolling SyncByPolling) `shouldEqual` true
             it "should be false" do
                 (syncByPolling SyncBySocket) `shouldEqual` false
+        describe "isTestnet" do
+            it "should be true" do
+                (isTestnet "https://www.testnet.cardanoexplorer.com/") `shouldEqual` true
+            it "should be false" do
+                (isTestnet "https://www.cardanoexplorer.com") `shouldEqual` false

--- a/frontend/src/Explorer/Util/Config.purs
+++ b/frontend/src/Explorer/Util/Config.purs
@@ -1,18 +1,25 @@
 module Explorer.Util.Config where
 
-import Control.Bind ((>>=))
+import Prelude
+
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
 import DOM.HTML (window)
 import DOM.HTML.Location (hostname) as L
 import DOM.HTML.Window (location)
 import Data.Generic (class Generic, gEq, gShow)
-import Prelude (class Eq, class Show, (==))
+import Data.Maybe (isJust)
+import Data.String.Regex (search)
+import Data.String.Regex.Flags (noFlags)
+import Data.String.Regex.Unsafe (unsafeRegex)
 
-foreign import versionImpl :: Int
+foreign import versionImpl :: String
 
-version :: Int
+version :: String
 version = versionImpl
+
+testNetVersion :: String
+testNetVersion = "0.5"
 
 foreign import commitHashImpl :: String
 
@@ -45,3 +52,7 @@ syncBySocket = (==) SyncBySocket
 
 syncByPolling :: SyncAction -> Boolean
 syncByPolling = (==) SyncByPolling
+
+isTestnet :: String -> Boolean
+isTestnet location =
+  isJust $ search (unsafeRegex "testnet\\." noFlags) location

--- a/frontend/src/Explorer/View/Block.purs
+++ b/frontend/src/Explorer/View/Block.purs
@@ -8,7 +8,7 @@ import Data.Lens ((^.))
 import Data.Maybe (Maybe(..), isJust)
 
 import Explorer.I18n.Lang (Language, translate)
-import Explorer.I18n.Lenses (cBlock, blSlotNotFound, common, cBack2Dashboard, cOf, cLoading, cNotAvailable, block, blFees, blRoot, blNextBlock, blPrevBlock, blEstVolume, cHash, cSummary, cTotalOutput, cHashes, cSlot, cTransactions, tx, txNotFound, txEmpty) as I18nL
+import Explorer.I18n.Lenses (cBlock, blSlotNotFound, common, cBack2Dashboard, cOf, cLoading, cNotAvailable, block, blFees, blRoot, blNextBlock, blPrevBlock, cHash, cSummary, cTotalOutput, cHashes, cSlot, cTransactions, tx, txNotFound, txEmpty) as I18nL
 import Explorer.Lenses.State (_PageNumber, blockDetail, blockTxPagination, blockTxPaginationEditable, currentBlockSummary, currentBlockTxs, lang, viewStates)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (minPagination)

--- a/frontend/src/Explorer/View/Blocks.purs
+++ b/frontend/src/Explorer/View/Blocks.purs
@@ -19,7 +19,7 @@ import Data.String (take)
 import Data.Time.Duration (Milliseconds)
 
 import Explorer.I18n.Lang (Language, translate)
-import Explorer.I18n.Lenses (block, blEpochSlotNotFound, cBack2Dashboard, cLoading, cOf, common, cUnknown, cEpoch, cSlot, cAge, cTransactions, cTotalSent, cBlockLead, cSize) as I18nL
+import Explorer.I18n.Lenses (block, blEpochSlotNotFound, cBack2Dashboard, cLoading, cOf, common, cUnknown, cEpoch, cSlot, cTransactions, cTotalSent, cBlockLead, cSize) as I18nL
 import Explorer.Lenses.State (_PageNumber, blocksViewState, blsViewPagination, blsViewPaginationEditable, currentBlocksResult, lang, viewStates)
 import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (minPagination)
@@ -28,7 +28,7 @@ import Explorer.Types.State (CBlockEntries, CCurrency(..), PageNumber(..), State
 import Explorer.Util.Factory (mkEpochIndex)
 import Explorer.Util.String (formatADA)
 import Explorer.Util.Time (prettyDuration, nominalDiffTimeToDateTime)
-import Explorer.View.CSS (blocksBody, blocksBodyRow, blocksColumnAge, blocksColumnEpoch, blocksColumnLead, blocksColumnSize, blocksColumnSlot, blocksColumnTotalSent, blocksColumnTxs, blocksFailed, blocksFooter, blocksHeader) as CSS
+import Explorer.View.CSS (blocksBody, blocksBodyRow, blocksColumnEpoch, blocksColumnLead, blocksColumnSize, blocksColumnSlot, blocksColumnTotalSent, blocksColumnTxs, blocksFailed, blocksFooter, blocksHeader) as CSS
 import Explorer.View.Common (currencyCSSClass, getMaxPaginationNumber, noData, paginationView)
 
 import Network.RemoteData (RemoteData(..), withDefault)

--- a/frontend/src/Explorer/View/Common.purs
+++ b/frontend/src/Explorer/View/Common.purs
@@ -43,6 +43,7 @@ import Explorer.Util.DOM (enterKeyPressed)
 import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
 import Explorer.Util.String (formatADA)
 import Explorer.Util.Time (prettyDate)
+import Explorer.Util.Config (testNetVersion)
 import Explorer.View.Lenses (txbAmount, txbInputs, txbOutputs, txhAmount, txhHash, txhTimeIssued)
 import Exporer.View.Types (TxBodyViewProps(..), TxHeaderViewProps(..))
 
@@ -301,26 +302,32 @@ txEmptyContentView message =
 -- logo
 -- -----------------
 
-logoView' :: Maybe Route -> P.HTML Action
-logoView' mRoute =
+logoView' :: Maybe Route -> Boolean -> P.HTML Action
+logoView' mRoute isTestnet =
     let logoContentTag = case mRoute of
                               Just route ->
                                   S.a ! S.href (toUrl route)
                                       #! P.onClick (Navigate $ toUrl route)
-                                      $ mempty
                               Nothing ->
-                                  S.div $ mempty
+                                  S.div
+
+        iconHiddenClazz = if isTestnet then "" else " hide"
     in
-    S.div ! S.className "logo__container"
-          $ S.div ! S.className "logo__wrapper"
-                  $ logoContentTag  ! S.className "logo__img bg-logo"
-                                    ! S.href (toUrl Dashboard)
+    S.div
+        ! S.className "logo__container"
+        $ S.div
+            ! S.className "logo__wrapper"
+            $ logoContentTag
+                ! S.className "logo__img bg-logo"
+                $ S.div
+                    ! S.className ("testnet-icon" <> iconHiddenClazz)
+                    $ S.text ("TN " <> testNetVersion)
 
-logoView :: P.HTML Action
-logoView = logoView' Nothing
+logoView :: Boolean -> P.HTML Action
+logoView isTestnet = logoView' Nothing isTestnet
 
-clickableLogoView :: Route -> P.HTML Action
-clickableLogoView = logoView' <<< Just
+clickableLogoView :: Route -> Boolean -> P.HTML Action
+clickableLogoView route isTestnet = logoView' (Just route) isTestnet
 
 -- -----------------
 -- lang

--- a/frontend/src/Explorer/View/Dashboard/Hero.purs
+++ b/frontend/src/Explorer/View/Dashboard/Hero.purs
@@ -8,7 +8,7 @@ import Data.Lens ((^.))
 
 import Explorer.I18n.Lang (translate)
 import Explorer.I18n.Lenses (common, hero, cTitle, hrSubtitle) as I18nL
-import Explorer.Lenses.State (lang)
+import Explorer.Lenses.State (testnet, lang)
 import Explorer.State (heroSearchContainerId)
 import Explorer.Types.Actions (Action)
 import Explorer.Types.State (State)
@@ -30,7 +30,7 @@ heroView state =
     S.div ! S.className "explorer-dashboard__hero"
           ! S.id "explorer-dashboard__hero-id"
           $ S.div ! S.className "hero-container" $ do
-                logoView
+                logoView $ state ^. testnet
                 S.h1  ! S.className "hero-headline"
                       $ S.text (translate (I18nL.common <<< I18nL.cTitle) lang')
                 S.h2  ! S.className "hero-subheadline"

--- a/frontend/src/Explorer/View/Footer.purs
+++ b/frontend/src/Explorer/View/Footer.purs
@@ -50,7 +50,7 @@ footerView state =
                       $ langView state
             S.div ! S.className "explorer-footer__container explorer-footer__meta" $ do
                 S.span  ! S.className "version"
-                        $ S.text ("v. " <> (show version))
+                        $ S.text ("v. " <> version)
                 S.a ! S.className "commit"
                     ! S.href ("https://github.com/input-output-hk/cardano-sl-explorer/commit/" <> commitHash)
                     $ S.text $ "( " <> (take 7 $ commitHash) <> " )"

--- a/frontend/src/Explorer/View/Header.purs
+++ b/frontend/src/Explorer/View/Header.purs
@@ -6,7 +6,7 @@ import Data.Lens ((^.))
 import Data.Monoid (mempty)
 import Explorer.I18n.Lang (Language, translate)
 import Explorer.I18n.Lenses (common, cAddress, cBlock, cCalculator, cEpoch, cSlot, cTitle, cTransaction, notfound, nfTitle) as I18nL
-import Explorer.Lenses.State (gViewMobileMenuOpenend, gViewSelectedSearch, globalViewState, lang, route, viewStates)
+import Explorer.Lenses.State (gViewMobileMenuOpenend, gViewSelectedSearch, globalViewState, testnet, lang, route, viewStates)
 import Explorer.Routes (Route(..))
 import Explorer.State (headerSearchContainerId, mobileMenuSearchContainerId)
 import Explorer.Types.Actions (Action(..))
@@ -31,7 +31,7 @@ headerView state =
               ! S.id CSS.headerId $ do
         S.div ! S.className "explorer-header__wrapper--vtop"
               $ S.div ! S.className "explorer-header__container" $ do
-                  clickableLogoView Dashboard
+                  clickableLogoView Dashboard $ state ^. testnet
                   -- desktop views
                   S.div ! S.className "middle-content__search"
                         $ S.div ! S.className "middle-content__search--wrapper"

--- a/frontend/src/Explorer/View/common.css
+++ b/frontend/src/Explorer/View/common.css
@@ -337,9 +337,32 @@
 }
 
 .logo__img {
+  position: relative;
   box-item: center;
   background-repeat: no-repeat;
   background-position: center center;
+}
+
+.testnet-icon {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  margin-left: 3px;
+  padding: 1px 2px;
+  border-radius: 3px;
+  background-color: var(--color15);
+  color: var(--color0);
+  font-family: var(--fontFamily0-Regular);
+  font-size: 7px;
+  white-space: nowrap;
+
+  @media (--md) {
+    top: -1px;
+    margin-left: 6px;
+    font-size: 9px;
+    padding: 2px 3px;
+    border-radius: 2px;
+  }
 }
 
 

--- a/frontend/src/Main.purs
+++ b/frontend/src/Main.purs
@@ -14,13 +14,13 @@ import Data.Lens ((^.), set)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Explorer.Api.Socket (addressTxsUpdatedEventHandler, blocksPageUpdatedEventHandler, callYouEventHandler, mkSocketHost, connectEvent, closeEvent, connectHandler, closeHandler, toEvent, txsUpdatedHandler) as Ex
 import Explorer.I18n.Lang (Language(..), detectLocale)
-import Explorer.Lenses.State (connection, lang, socket, syncAction)
+import Explorer.Lenses.State (connection, testnet, lang, socket, syncAction)
 import Explorer.Routes (match)
 import Explorer.Types.Actions (Action(..), ActionChannel) as Ex
 import Explorer.Types.App (AppEffects)
 import Explorer.Types.State (State) as Ex
 import Explorer.Update (update) as Ex
-import Explorer.Util.Config (SyncAction(..), hostname, isProduction, secureProtocol)
+import Explorer.Util.Config (SyncAction(..), hostname, isTestnet, isProduction, secureProtocol)
 import Explorer.View.Layout (view)
 import Pos.Explorer.Socket.Methods (ServerEvent(..))
 import Pux (App, Config, CoreEffects, start)
@@ -83,8 +83,13 @@ commonConfig state actionChannel = do
                 htmlDocumentToEventTarget >>>
                     addEventListener click (eventListener globalClickListener) false
 
+    isTestnet' <- isTestnet <$> hostname
+
     pure
-        { initialState: set lang locale state
+        { initialState:
+            set lang locale $
+            set testnet isTestnet' $
+            state
         , foldp: Ex.update
         , view
         , inputs:

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -21,6 +21,7 @@
 	--color12: #e6e6e6;
 	--color13: #aaa;
 	--color14: #f9f9f9;
+	--color15: #9a1805;
 
   /* fonts */
   --fontFamily0-Light: 'fontFamily0-Light';


### PR DESCRIPTION
To check the `test-net` icon locally set `testnet` to `true` (instead of to `isTestnet'`) here https://github.com/input-output-hk/cardano-sl-explorer/blob/feature/CSE-180-main-test-net-info/frontend/src/Main.purs#L91

P.S. This PR includes some tiny fixes (removing unused imports + fix type of `version`)