### PR TITLE
CSE-183 Order of slots is reversed in Block Feed.

### DIFF
--- a/src/Pos/Explorer/Web/Server.hs
+++ b/src/Pos/Explorer/Web/Server.hs
@@ -209,7 +209,7 @@ getBlocksPage mPageNumber pageSize = do
     cBlocksEntry    <- forM (rights blocks) toBlockEntry
 
     -- Return total pages and the blocks. We start from page 1.
-    pure (totalPages, cBlocksEntry)
+    pure (totalPages, reverse cBlocksEntry)
   where
 
     -- Either get the @HeaderHash@es from the @Page@ or throw an exception.


### PR DESCRIPTION
https://issues.serokell.io/issue/CSE-183

Reversed the blocks/slots ordering. Tested on `dev` and `testnet`.