### PR TITLE
CSE-176 Switch to wai.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Unless a later match takes precedence, @akegalj will be requested
+# for review when someone opens a pull request.
+
+*                               @akegalj
+
+# Order is important; the last matching pattern takes the most precedence.
+
+*.purs                          @sectore
+frontend/                       @sectore
+
+src/                            @ksaric
+src/Pos/Explorer/Socket/        @martoon
+test/                           @ksaric

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# PR
+
+---
+
+Youtrack issue URL - **LINK**
+
+---
+
+Short description - **DESCRIBE**
+
+---
+
+How did I test this new functionality/bug fix?
+
+1. branch I used
+2. how did I run the project - was it on _DEV_, _TESTNET_, something else?
+3. steps to reproduce the new behaviour, if I have additional tests, please write them down
+
+---
+
+- [ ] PR was tested, and is linted.
+

--- a/cardano-sl-explorer.cabal
+++ b/cardano-sl-explorer.cabal
@@ -32,33 +32,8 @@ library
                       , aeson
                       , binary
                       , bytestring
+                      , containers
                       , base16-bytestring
-                      , cardano-sl
-                      , cardano-sl-core
-                      , cardano-sl-infra
-                      , cardano-sl-db
-                      , cardano-sl-ssc
-                      , engine-io
-                      , engine-io-snap
-                      , exceptions
-                      , either
-                      , ether >= 0.5.1
-                      , formatting
-                      , lens
-                      , log-warper
-                      , lifted-base
-                      , mtl
-                      , monad-control
-                      , monad-loops
-                      , node-sketch
-                      , serokell-util
-                      , servant
-                      , servant-server
-                      , socket-io
-                      , snap-core
-                      , snap-cors
-                      , snap-server
-                      , engine-io-wai
                       , stm
                       , tagged
                       , text-format
@@ -68,9 +43,40 @@ library
                       , transformers
                       , universum
                       , unordered-containers
+                      , node-sketch
+                      , serokell-util
+                      , exceptions
+                      , either
+                      , ether >= 0.5.1
+                      , formatting
+                      , lens
+                      , log-warper
+
+                      -- cardano sl
+                      , cardano-sl
+                      , cardano-sl-core
+                      , cardano-sl-infra
+                      , cardano-sl-db
+                      , cardano-sl-ssc
+
+                      -- mtl ++
+                      , lifted-base
+                      , mtl
+                      , monad-control
+                      , monad-loops
+
+                      -- servant
+                      , servant
+                      , servant-server
+                      , http-types
+
+                      -- socket-io + deps
+                      , socket-io
+                      , engine-io
+                      , engine-io-wai
                       , wai
+                      , wai-cors
                       , warp
-                      , containers
   hs-source-dirs:       src
   default-language:     Haskell2010
   ghc-options:         -Wall

--- a/scripts/build/clean.sh
+++ b/scripts/build/clean.sh
@@ -17,4 +17,5 @@ rm -rf node-db/
 rm -rf node-*.*key*
 rm -rf kademlia-abc.dump
 rm -rf *.log
-
+rm *key*
+rm kademlia.dump

--- a/src/Pos/Explorer/Socket/App.hs
+++ b/src/Pos/Explorer/Socket/App.hs
@@ -139,7 +139,8 @@ notifierServer notifierSettings connVar = do
                     Just $ simpleCorsResourcePolicy { corsOrigins = Just ([bsValue], True) }
                 -- If we didn't find the "Origin" header then the result is
                 -- "Access-Control-Allow-Origin = '*'", which WON'T WORK FOR socket.io.
-                Nothing           -> Nothing
+                Nothing           ->
+                    Just $ simpleCorsResourcePolicy
 
           where
             findJustOriginValue :: [Header]

--- a/src/Pos/Explorer/Socket/Util.hs
+++ b/src/Pos/Explorer/Socket/Util.hs
@@ -27,11 +27,11 @@ import qualified Data.Map                 as M
 import           Data.Text                (Text)
 import           Data.Time.Units          (TimeUnit (..))
 import           Formatting               (sformat, shown, (%))
+import           Network.EngineIO.Wai     (WaiMonad)
 
 import           Mockable                 (Fork, Mockable, fork)
 import qualified Network.SocketIO         as S
 import           Serokell.Util.Concurrent (threadDelay)
-import           Snap.Core                (Snap)
 import           System.Wlog              (CanLog (..), WithLogger, logWarning)
 import           Universum                hiding (on)
 
@@ -75,7 +75,7 @@ on eventName = S.on (toName eventName)
 
 -- * Instances
 
-instance CanLog Snap where
+instance CanLog WaiMonad where
     dispatchMessage logName sev msg = liftIO $ dispatchMessage logName sev msg
 
 -- * Misc

--- a/stack.yaml
+++ b/stack.yaml
@@ -104,30 +104,18 @@ extra-deps:
 - transformers-lift-0.2.0.1
 
 # The other dependencies that we need to revise
-- UtilityTM-0.0.4
 - derive-2.6.2                    # not yet in lts-8
-- wreq-0.5.0.0                    # not yet in lts-8
+- lens-4.15.3                     # not yet in lts-8
+- th-abstraction-0.2.2.0          # needed for lens
+
 - turtle-1.3.1                    # earlier versions don't have 'stat'
 - optparse-applicative-0.13.0.0   # needed for turtle
 - criterion-1.1.4.0               # older criterion doesn't like optparse-0.13
 - code-page-0.1.1                 # needed for criterion
-- websockets-snap-0.10.2.0
-- websockets-0.9.8.2
-- aeson-1.0.2.1
-- engine-io-snap-1.0.4
-- heist-1.0.1.0
-- map-syntax-0.2.0.2
-- snap-1.0.0.1
-- snap-cors-1.2.11
-- foundation-0.0.9
-- memory-0.14.5
-- writer-cps-transformers-0.1.1.3
-- writer-cps-mtl-0.1.1.4
-- rocksdb-haskell-1.0.0
-- generic-arbitrary-0.1.0
-- store-0.4.3.1
-- lens-4.15.3                     # not yet in lts-8
-- th-abstraction-0.2.2.0          # needed for lens
+
+- rocksdb-haskell-1.0.0           # required for cardano-sl stack solving
+- generic-arbitrary-0.1.0         # required for cardano-sl stack solving
+- store-0.4.3.1                   # required for cardano-sl Pos.Binary.Crypto
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything


### PR DESCRIPTION
https://issues.serokell.io/issue/CSE-176

I had an issue with socket.io and had to spend quite a bit of time trying to understand why - https://github.com/socketio/socket.io-client/issues/641

In the end, I had to add a piece of `Middleware` which seems kind of complicated, but consists of adding a Request "Origin" value to the Response "Access-Control-Allow-Origin" header, bypassing the issue.

You can see here how the two implementations differ:
- https://github.com/ocharles/snap-cors/blob/master/src/Snap/CORS.hs
- https://github.com/larskuhtz/wai-cors/blob/master/src/Network/Wai/Middleware/Cors.hs

Here are some useful links for understanding the changes:
- https://hackage.haskell.org/package/wai-3.2.1.1/docs/Network-Wai.html#t:Application
- https://hackage.haskell.org/package/wai-extra-3.0.20.0/docs/Network-Wai-Middleware-AddHeaders.html
- https://hackage.haskell.org/package/http-types-0.9.1/docs/Network-HTTP-Types-Header.html#t:Header

I removed all the dependencies I could, and run `stack clean --full && stack install` at the end. Seems I cleaned most (all?) of the extra dependencies.
In the end, it runs successfully and socket.io client is running.

Currently, there is no logging in the socket.io part of the code, which is not a big issue (the socket.io part works), but I spend quite a bit of time on this already and another issue for logging would be appropriate.

Also added the first version of `CODEOWNERS` and `PULL_REQUEST_TEMPLATE.md`. Please note that this is the first version and you can change it, I really don't know which part of the code "belongs" to who.

